### PR TITLE
Virtualized scroll, editable SQL, data-first viewer, temp cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the "duckdb" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+
+### Added
+- **Editable SQL modal** — every "View SQL" / "SQL Preview" modal is now a SQL editor: tweak the query and press ⌘↵ / Ctrl+↵ to run it in place. Works for the file overview preview, the original-query modal in the results table, and the filtered/sorted full-query modal. "Open in Editor" now uses the edited text. Tab inserts spaces.
+- **Land directly on data** — opening a `.parquet` (or other data file) now jumps straight into the data view instead of the schema overview. The schema view is still one click away via "Back to Overview".
+- New `duckdb.fileViewer.openMode` setting (`data` | `schema`, default `data`) and `duckdb.fileViewer.openRowLimit` (default `0` = unlimited) to control the new landing behaviour.
+- Skeleton-cell shimmer for rows whose chunk hasn't arrived yet — visible while you scroll faster than chunks fetch.
+
+### Changed
+- **Virtualized infinite scroll for results.** Auto-open no longer applies a `LIMIT` by default; the full result set is materialized into a DuckDB temp table and rows are streamed into the viewport on demand in 100-row chunks. Only the rows currently in (or near) the viewport live in the DOM, so scrolling 10M rows does not OOM the webview. A bounded LRU chunk cache (~80 chunks ≈ 8k rows) keeps memory flat as you scroll. Pagination buttons are gone — the scrollbar maps directly to the full result set.
+- `duckdb.pageSize` now defaults to `100` (the chunk size for infinite scroll) instead of `1000`.
+- The data viewer's refresh button now re-runs the most recent query (default top-N, ad-hoc edit, or column selection) instead of dropping back to the schema view.
+- The `requestPage` IPC echoes a `requestVersion` so chunk responses from prior sort/filter contexts are dropped instead of corrupting the cache.
+- DuckDB now spills to a per-process subdirectory under `<os.tmpdir>/duckdb-vscode/pid-<pid>-<random>/` (created via `mkdtempSync`); the directory is removed on extension shutdown so spill files don't accumulate across sessions. User-configured `duckdb.tempDirectory` is respected and never deleted.
+- Bumped `@duckdb/node-api` from `1.4.3-r.3` to `1.5.2-r.1`.
+
+### Fixed
+- When an auto-loaded query errors out, a "Back to Schema" recovery button appears so the session is not stuck on the error screen.
+
+### Notes
+- `Cmd+A` followed by Copy on a huge result set is intentionally capped at 10,000 rows (with a trailing `-- truncated` marker). For full exports, use the **Copy Table** / **Export** buttons in the footer — those use the server-side copy path and respect `duckdb.maxCopyRows`.
+
 ## [0.0.24] - 2026-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Notes
 - `Cmd+A` followed by Copy on a huge result set is intentionally capped at 10,000 rows (with a trailing `-- truncated` marker). For full exports, use the **Copy Table** / **Export** buttons in the footer — those use the server-side copy path and respect `duckdb.maxCopyRows`.
 
+### Added (continued)
+- **Resizable row-number gutter.** Default width now scales with the digit count of the current result set (so `10,000,000` doesn't clip), and a drag handle on the `#` header lets you resize it like any other column. Row indexes are formatted with thousands separators.
+- **Editable cells with save-to-file.** Double-click a cell in the data viewer to open the expansion modal in **edit** mode — type the new value and press ⌘↵ (or click Save) to persist. Save UPDATEs the in-memory DuckDB cache and rewrites the source file via `COPY ... TO 'tmp'` followed by an atomic rename, so a crash mid-write can never corrupt the original. Empty input means NULL; `TRY_CAST` makes type-incompatible input fall back to NULL instead of erroring. Supported formats: `parquet`, `csv`, `tsv`, `json`, `jsonl`, `ndjson`. Editing is gated to safe contexts only — disabled when the cache is a derived projection, a `LIMIT`-sampled load, an ad-hoc SQL result, or an `xlsx` sheet (no DuckDB write support). Complex types (`LIST`, `STRUCT`, `MAP`) are read-only for now.
+
 ## [0.0.24] - 2026-03-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "duckdb",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duckdb",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-api": "^1.4.3-r.3",
+        "@duckdb/node-api": "^1.5.2-r.1",
         "fzf": "^0.5.2",
         "lucide-react": "^0.563.0",
         "react": "^19.2.3",
@@ -258,31 +258,32 @@
       }
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.3-r.3.tgz",
-      "integrity": "sha512-lPHpmYRMoFJkTCZmp76sETTNPly7lT3eJfV69vqsZE3wur+OY9VW/BflMQ41mP1vSucGqw4rY6XCSmMACE7bwQ==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.2-r.1.tgz",
+      "integrity": "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-bindings": "1.4.3-r.3"
+        "@duckdb/node-bindings": "1.5.2-r.1"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.3-r.3.tgz",
-      "integrity": "sha512-QrkUgZw4Xwn5lNbvUHXcF3F5OvVexf9uQyJnxrLTzs9P93Be0UB+b4hr1EZwf1OMMocchN9iG1R839aVIfSJBg==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.2-r.1.tgz",
+      "integrity": "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==",
       "license": "MIT",
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.4.3-r.3",
-        "@duckdb/node-bindings-darwin-x64": "1.4.3-r.3",
-        "@duckdb/node-bindings-linux-arm64": "1.4.3-r.3",
-        "@duckdb/node-bindings-linux-x64": "1.4.3-r.3",
-        "@duckdb/node-bindings-win32-x64": "1.4.3-r.3"
+        "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.5.2-r.1",
+        "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.5.2-r.1"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.3-r.3.tgz",
-      "integrity": "sha512-iyVZbanRsZKSoK1BHqC61+PExyFUjJ7Ftz+BVN6xsWvB3tfkBBwEcZ5K/cCkHuCqmT7IcUwwDoc89Naz7Tze/A==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==",
       "cpu": [
         "arm64"
       ],
@@ -293,9 +294,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.3-r.3.tgz",
-      "integrity": "sha512-exWYLzYLlKqsTp92iBR8SEcaMJpOWbUjaTmNN48TYCjDzLXPW2r4G2xhbFA67KuxnBJcrGvwNOOFcBje2AhfHg==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==",
       "cpu": [
         "x64"
       ],
@@ -306,9 +307,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.3-r.3.tgz",
-      "integrity": "sha512-Jx3SS6Hy2l3TuHUZ9iJ/b2ZnajfFV7AB1TMEh2gE1mmytoVkqjiMvVRj7487u4pxEANj9ELYXspdspC4/wyOaA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==",
       "cpu": [
         "arm64"
       ],
@@ -319,9 +320,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.3-r.3.tgz",
-      "integrity": "sha512-1ISlvsyQheiJlr8tdtVJ0cfCsjBB2leQZL82KJHFKx4Q5gj4yWRYi4tfaPup9zk5rY0xXSuVuhBxKPkTX1UZqg==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==",
       "cpu": [
         "x64"
       ],
@@ -331,10 +332,23 @@
         "linux"
       ]
     },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.4.3-r.3",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.3-r.3.tgz",
-      "integrity": "sha512-DQBGxcIZ6yatHrcxIevejKsyj1cobu6BwXU17YuxCSA/BxdfEl7QnhBzwEpDJUDj6gUbLbBqsEvwY+K/NWAwEg==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -706,10 +706,10 @@
         },
         "duckdb.pageSize": {
           "type": "number",
-          "default": 1000,
-          "minimum": 100,
+          "default": 100,
+          "minimum": 10,
           "maximum": 10000,
-          "description": "Number of rows per page in results table"
+          "description": "Rows fetched per chunk when the results table loads more rows during infinite scroll."
         },
         "duckdb.maxCopyRows": {
           "type": "number",
@@ -837,6 +837,26 @@
           "default": true,
           "markdownDescription": "Automatically open `.parquet` files with the DuckDB data viewer, replacing the default binary file error."
         },
+        "duckdb.fileViewer.openMode": {
+          "type": "string",
+          "enum": [
+            "data",
+            "schema"
+          ],
+          "default": "data",
+          "enumDescriptions": [
+            "Immediately load the first N rows of data (use the schema overview via the Back button)",
+            "Show the schema/column overview first; user picks what to query"
+          ],
+          "markdownDescription": "Default landing view when opening a data file (parquet, CSV, JSON, etc.).\n\n- `data` (default): jumps straight into rows — see [`#duckdb.fileViewer.openRowLimit#`](command:workbench.action.openSettings?%22duckdb.fileViewer.openRowLimit%22) for the limit.\n- `schema`: keeps the previous behaviour of showing column metadata first."
+        },
+        "duckdb.fileViewer.openRowLimit": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 100000000,
+          "markdownDescription": "Optional cap on rows materialized when [`#duckdb.fileViewer.openMode#`](command:workbench.action.openSettings?%22duckdb.fileViewer.openMode%22) is `data`.\n\n- `0` (default) — no cap; the full result set is loaded into a DuckDB temp table and rows are streamed into the table on demand via infinite scroll.\n- `> 0` — applies `LIMIT N` to the auto-open query. Useful for huge files where you only want a sample."
+        },
         "duckdb.fileViewer.csv": {
           "type": "boolean",
           "default": true,
@@ -927,7 +947,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@duckdb/node-api": "^1.4.3-r.3",
+    "@duckdb/node-api": "^1.5.2-r.1",
     "fzf": "^0.5.2",
     "lucide-react": "^0.563.0",
     "react": "^19.2.3",

--- a/src/providers/DataFileEditorProvider.ts
+++ b/src/providers/DataFileEditorProvider.ts
@@ -112,6 +112,20 @@ export class DataFileEditorProvider
         }
         return sql;
       },
+
+      getWriteBackTarget() {
+        // xlsx is excluded — DuckDB's excel extension is read-only.
+        const writableFormats: Record<string, "parquet" | "csv" | "tsv" | "json" | "jsonl" | "ndjson"> = {
+          parquet: "parquet",
+          csv: "csv",
+          tsv: "tsv",
+          json: "json",
+          jsonl: "jsonl",
+          ndjson: "ndjson",
+        };
+        const fmt = writableFormats[fileType];
+        return fmt ? { path: filePath, format: fmt } : null;
+      },
     };
 
     setupOverviewWebview(webviewPanel, this.context, source, {

--- a/src/providers/DataFileEditorProvider.ts
+++ b/src/providers/DataFileEditorProvider.ts
@@ -114,7 +114,9 @@ export class DataFileEditorProvider
       },
     };
 
-    setupOverviewWebview(webviewPanel, this.context, source);
+    setupOverviewWebview(webviewPanel, this.context, source, {
+      autoLoad: getAutoLoadOptions(),
+    });
   }
 
   /**
@@ -152,7 +154,9 @@ export class DataFileEditorProvider
         documentUri,
         db
       );
-      setupOverviewWebview(webviewPanel, this.context, source);
+      setupOverviewWebview(webviewPanel, this.context, source, {
+        autoLoad: getAutoLoadOptions(),
+      });
       return;
     }
 
@@ -263,6 +267,21 @@ export class DataFileEditorProvider
     }
     return filePath;
   }
+}
+
+/**
+ * Resolve the auto-load options when opening a data file.
+ * Returns undefined when openMode is "schema" (auto-load disabled).
+ *
+ * `limit: undefined` (or 0 in settings) means "no LIMIT" — the full result
+ * set is materialized and the table loads rows on demand via infinite scroll.
+ */
+function getAutoLoadOptions(): { limit?: number } | undefined {
+  const cfg = vscode.workspace.getConfiguration("duckdb");
+  const mode = cfg.get<string>("fileViewer.openMode", "data");
+  if (mode !== "data") return undefined;
+  const limit = cfg.get<number>("fileViewer.openRowLimit", 0);
+  return { limit: limit > 0 ? limit : undefined };
 }
 
 // ============================================================================

--- a/src/providers/overviewHandler.ts
+++ b/src/providers/overviewHandler.ts
@@ -25,6 +25,13 @@ export type { DataOverviewMetadata, ContainerOverviewMetadata };
 // DataSource interface
 // ============================================================================
 
+/** Persistent target for in-place edits. Returned by sources that can be
+ * safely overwritten via DuckDB's COPY (parquet, csv, tsv, json, jsonl). */
+export interface WriteBackTarget {
+  path: string;
+  format: "parquet" | "csv" | "tsv" | "json" | "jsonl" | "ndjson";
+}
+
 /**
  * Abstraction over the data source (file or table).
  * Each provider implements this to plug into the shared handler.
@@ -48,6 +55,13 @@ export interface OverviewDataSource {
 
   /** Build a SELECT SQL with optional column selection and limit. */
   buildSelectSql(columns?: string[], limit?: number): string;
+
+  /**
+   * Where (and in what format) cell edits get persisted. Returning null
+   * disables editing for this source (e.g. xlsx, virtual tables, derived
+   * results that can't be safely overwritten).
+   */
+  getWriteBackTarget?(): WriteBackTarget | null;
 }
 
 // ============================================================================
@@ -92,6 +106,13 @@ export function setupOverviewWebview(
   // Used so "refresh" re-runs the last query rather than dropping back to
   // the schema overview.
   let lastQuerySql: string | undefined;
+  /**
+   * Whether the current cache reflects the *full, unmodified* source — only
+   * then is it safe to write cell edits back to the source file. Set true
+   * when the auto-load runs `SELECT *` with no LIMIT; false for column
+   * projections, LIMITed samples, and ad-hoc SQL.
+   */
+  let cacheIsFullSource = false;
 
   // Set up webview options and content
   panel.webview.options = {
@@ -153,19 +174,29 @@ export function setupOverviewWebview(
 
   // ------------------------------------------------------------------
   // Run an arbitrary SQL, post results, and remember it for refresh.
+  // `editable` controls whether cell edits get persisted back to the
+  // source — only true for unbounded SELECT * loads where the cache
+  // is a faithful copy of the source.
   // ------------------------------------------------------------------
-  async function runQuery(querySql: string, status: string): Promise<void> {
+  async function runQuery(
+    querySql: string,
+    status: string,
+    opts: { editable?: boolean } = {}
+  ): Promise<void> {
     try {
       sendLoadingStatus(status);
       resetCaches();
       lastQuerySql = querySql;
+      cacheIsFullSource = !!opts.editable;
       const result = await db.executeQuery(querySql, pageSize);
       cacheIds = collectCacheIds(result);
+      const writeTarget = source.getWriteBackTarget?.() ?? null;
       panel.webview.postMessage({
         type: "queryResult",
         data: result,
         pageSize,
         maxCopyRows,
+        editable: cacheIsFullSource && writeTarget !== null,
       });
     } catch (error) {
       panel.webview.postMessage({
@@ -204,7 +235,10 @@ export function setupOverviewWebview(
           const status = limit
             ? `Loading first ${limit.toLocaleString()} rows…`
             : "Materializing results…";
-          await runQuery(source.buildSelectSql(undefined, limit), status);
+          // Editable only when the cache is the full unbounded source.
+          await runQuery(source.buildSelectSql(undefined, limit), status, {
+            editable: !limit,
+          });
         } else {
           await sendMetadata();
         }
@@ -212,7 +246,10 @@ export function setupOverviewWebview(
 
       case "queryFile": {
         const querySql = source.buildSelectSql(message.columns, message.limit);
-        await runQuery(querySql, "Running query…");
+        // Editable only when the user picks "All rows" with no projection.
+        const editable =
+          (!message.columns || message.columns.length === 0) && !message.limit;
+        await runQuery(querySql, "Running query…", { editable });
         break;
       }
 
@@ -233,7 +270,48 @@ export function setupOverviewWebview(
 
       case "runAdHoc": {
         if (typeof message.sql !== "string" || !message.sql.trim()) break;
-        await runQuery(message.sql, "Running query…");
+        // Ad-hoc edits produce a derived result; never safe to write back.
+        await runQuery(message.sql, "Running query…", { editable: false });
+        break;
+      }
+
+      case "updateCell": {
+        const { rowId, column, columnType, newValue } = message;
+        const target = source.getWriteBackTarget?.() ?? null;
+        try {
+          if (!cacheIsFullSource) {
+            throw new Error(
+              "Editing is disabled for derived or limited results. Reload the file with the default view to edit."
+            );
+          }
+          if (!target) {
+            throw new Error("This file format does not support write-back.");
+          }
+          if (cacheIds.length === 0) throw new Error("No cache to edit");
+          const cacheId = cacheIds[0];
+          const stored = await db.updateCacheCell(
+            cacheId,
+            Number(rowId),
+            column,
+            columnType,
+            newValue ?? null
+          );
+          await db.writeCacheToFile(cacheId, target.path, target.format);
+          panel.webview.postMessage({
+            type: "cellUpdated",
+            cacheId,
+            rowId,
+            column,
+            newValue: stored,
+          });
+        } catch (error) {
+          panel.webview.postMessage({
+            type: "cellUpdated",
+            rowId,
+            column,
+            error: String(error instanceof Error ? error.message : error),
+          });
+        }
         break;
       }
 
@@ -586,6 +664,8 @@ export function setupMultiTableOverviewWebview(
             data: result,
             pageSize,
             maxCopyRows,
+            // Multi-table sources (xlsx) never support write-back.
+            editable: false,
           });
         } catch (error) {
           panel.webview.postMessage({
@@ -624,6 +704,8 @@ export function setupMultiTableOverviewWebview(
             data: result,
             pageSize,
             maxCopyRows,
+            // Multi-table sources (xlsx) never support write-back.
+            editable: false,
           });
         } catch (error) {
           panel.webview.postMessage({

--- a/src/providers/overviewHandler.ts
+++ b/src/providers/overviewHandler.ts
@@ -54,6 +54,20 @@ export interface OverviewDataSource {
 // Shared webview setup
 // ============================================================================
 
+/** Options that customize the initial webview behaviour. */
+export interface OverviewWebviewOptions {
+  /**
+   * If present, the panel auto-runs `SELECT * FROM <source>` after sending
+   * metadata, landing the user directly on the results view instead of the
+   * schema overview.
+   *
+   * - `limit` undefined or `0` → no LIMIT; the full result set is materialized
+   *   into the temp cache and rows stream into the table via infinite scroll.
+   * - `limit` > 0 → applies `LIMIT N`, useful for sampling huge files.
+   */
+  autoLoad?: { limit?: number };
+}
+
 /**
  * Configure a webview panel for the overview UI and wire up all message
  * handlers. Returns a Disposable that cleans up DuckDB caches.
@@ -61,17 +75,23 @@ export interface OverviewDataSource {
 export function setupOverviewWebview(
   panel: vscode.WebviewPanel,
   context: vscode.ExtensionContext,
-  source: OverviewDataSource
+  source: OverviewDataSource,
+  options: OverviewWebviewOptions = {}
 ): void {
   const config = vscode.workspace.getConfiguration("duckdb");
-  const pageSize = config.get<number>("pageSize", 1000);
+  const pageSize = config.get<number>("pageSize", 100);
   const maxCopyRows = config.get<number>("maxCopyRows", 50000);
   const db = getDuckDBService();
+  const autoLoad = options.autoLoad;
 
   // Mutable state shared across message handlers
   let cacheIds: string[] = [];
   let sortColumn: string | undefined;
   let sortDirection: "asc" | "desc" | undefined;
+  // The most recently executed query (default top-N, queryFile, or runAdHoc).
+  // Used so "refresh" re-runs the last query rather than dropping back to
+  // the schema overview.
+  let lastQuerySql: string | undefined;
 
   // Set up webview options and content
   panel.webview.options = {
@@ -109,13 +129,41 @@ export function setupOverviewWebview(
   // ------------------------------------------------------------------
   // Helper to send metadata to the webview
   // ------------------------------------------------------------------
-  async function sendMetadata(): Promise<void> {
+  async function sendMetadata(opts: { silent?: boolean } = {}): Promise<void> {
     try {
-      sendLoadingStatus("Fetching schema…");
+      if (!opts.silent) sendLoadingStatus("Fetching schema…");
       const metadata = await source.getMetadata();
       panel.webview.postMessage({
         type: "fileMetadata",
         data: metadata,
+        pageSize,
+        maxCopyRows,
+        // When silent, the webview stores metadata in state but does not
+        // switch the visible view — used so the "Back to Overview" button
+        // works while the user lands directly on the data results.
+        silent: opts.silent ?? false,
+      });
+    } catch (error) {
+      panel.webview.postMessage({
+        type: "queryError",
+        error: String(error),
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Run an arbitrary SQL, post results, and remember it for refresh.
+  // ------------------------------------------------------------------
+  async function runQuery(querySql: string, status: string): Promise<void> {
+    try {
+      sendLoadingStatus(status);
+      resetCaches();
+      lastQuerySql = querySql;
+      const result = await db.executeQuery(querySql, pageSize);
+      cacheIds = collectCacheIds(result);
+      panel.webview.postMessage({
+        type: "queryResult",
+        data: result,
         pageSize,
         maxCopyRows,
       });
@@ -147,36 +195,32 @@ export function setupOverviewWebview(
       // ---- Overview-specific (delegated to DataSource) ----
 
       case "ready":
-        await sendMetadata();
+        if (autoLoad) {
+          // Pre-fetch metadata silently so the Back-to-Overview button works,
+          // then jump straight into the data view.
+          await sendMetadata({ silent: true });
+          const limit =
+            autoLoad.limit && autoLoad.limit > 0 ? autoLoad.limit : undefined;
+          const status = limit
+            ? `Loading first ${limit.toLocaleString()} rows…`
+            : "Materializing results…";
+          await runQuery(source.buildSelectSql(undefined, limit), status);
+        } else {
+          await sendMetadata();
+        }
         break;
 
       case "queryFile": {
-        try {
-          sendLoadingStatus("Running query…");
-          resetCaches();
-          const querySql = source.buildSelectSql(
-            message.columns,
-            message.limit
-          );
-          const result = await db.executeQuery(querySql, pageSize);
-          cacheIds = collectCacheIds(result);
-          panel.webview.postMessage({
-            type: "queryResult",
-            data: result,
-            pageSize,
-            maxCopyRows,
-          });
-        } catch (error) {
-          panel.webview.postMessage({
-            type: "queryError",
-            error: String(error),
-          });
-        }
+        const querySql = source.buildSelectSql(message.columns, message.limit);
+        await runQuery(querySql, "Running query…");
         break;
       }
 
       case "openAsSql": {
-        const sql = source.buildSelectSql(message.columns);
+        const sql =
+          typeof message.sql === "string" && message.sql.trim().length > 0
+            ? message.sql
+            : source.buildSelectSql(message.columns);
         const doc = await vscode.workspace.openTextDocument({
           content: sql,
           language: "sql",
@@ -184,6 +228,12 @@ export function setupOverviewWebview(
         await vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,
         });
+        break;
+      }
+
+      case "runAdHoc": {
+        if (typeof message.sql !== "string" || !message.sql.trim()) break;
+        await runQuery(message.sql, "Running query…");
         break;
       }
 
@@ -223,14 +273,24 @@ export function setupOverviewWebview(
 
       case "refreshQuery":
         try {
-          resetCaches();
-          await sendMetadata();
+          if (lastQuerySql) {
+            await runQuery(lastQuerySql, "Refreshing…");
+          } else {
+            resetCaches();
+            await sendMetadata();
+          }
         } catch (error) {
           panel.webview.postMessage({
             type: "refreshError",
             error: String(error),
           });
         }
+        break;
+
+      // ---- Navigate to schema overview from results view ----
+
+      case "showOverview":
+        await sendMetadata();
         break;
 
       // ---- Cache-based handlers (identical for all sources) ----
@@ -250,11 +310,13 @@ export function setupOverviewWebview(
           panel.webview.postMessage({
             type: "pageData",
             data: pageData,
+            requestVersion: message.requestVersion,
           });
         } catch (error) {
           panel.webview.postMessage({
             type: "filterError",
             cacheId: message.cacheId,
+            requestVersion: message.requestVersion,
             error: String(error),
           });
         }
@@ -535,8 +597,11 @@ export function setupMultiTableOverviewWebview(
       }
 
       case "openAsSql": {
-        if (!activeSource) break;
-        const sql = activeSource.buildSelectSql(message.columns);
+        const sql =
+          typeof message.sql === "string" && message.sql.trim().length > 0
+            ? message.sql
+            : activeSource?.buildSelectSql(message.columns);
+        if (!sql) break;
         const doc = await vscode.workspace.openTextDocument({
           content: sql,
           language: "sql",
@@ -544,6 +609,28 @@ export function setupMultiTableOverviewWebview(
         await vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,
         });
+        break;
+      }
+
+      case "runAdHoc": {
+        try {
+          if (typeof message.sql !== "string" || !message.sql.trim()) break;
+          sendLoadingStatus("Running query…");
+          resetCaches();
+          const result = await db.executeQuery(message.sql, pageSize);
+          cacheIds = collectCacheIds(result);
+          panel.webview.postMessage({
+            type: "queryResult",
+            data: result,
+            pageSize,
+            maxCopyRows,
+          });
+        } catch (error) {
+          panel.webview.postMessage({
+            type: "queryError",
+            error: String(error),
+          });
+        }
         break;
       }
 
@@ -616,11 +703,13 @@ export function setupMultiTableOverviewWebview(
           panel.webview.postMessage({
             type: "pageData",
             data: pageData,
+            requestVersion: message.requestVersion,
           });
         } catch (error) {
           panel.webview.postMessage({
             type: "filterError",
             cacheId: message.cacheId,
+            requestVersion: message.requestVersion,
             error: String(error),
           });
         }

--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -687,8 +687,11 @@ export class DuckDBService {
     }
 
     try {
-      // Build query with optional filtering and sorting
-      let sql = `SELECT * FROM "${cacheId}"`;
+      // Build query with optional filtering and sorting.
+      // We always fetch DuckDB's `rowid` pseudo-column under the hidden field
+      // name `__rowid` so the webview can address a specific row for in-place
+      // edits regardless of the current sort/filter context.
+      let sql = `SELECT rowid AS __rowid, * FROM "${cacheId}"`;
       if (whereClause && whereClause.trim()) {
         sql += ` WHERE ${whereClause}`;
       }
@@ -725,6 +728,117 @@ export class DuckDBService {
     } catch (err) {
       const error = err as Error;
       throw new Error(`Failed to fetch page: ${error.message}`);
+    }
+  }
+
+  /**
+   * Update a single cell in a cached result by rowid.
+   *
+   * The user-entered string is wrapped in TRY_CAST so type-incompatible
+   * input becomes NULL instead of crashing. Empty input is treated as NULL.
+   * Returns the value as actually stored (post-cast) so the webview can
+   * reflect what DuckDB ended up writing.
+   */
+  async updateCacheCell(
+    cacheId: string,
+    rowid: number | bigint,
+    column: string,
+    columnType: string,
+    newValue: string | null
+  ): Promise<unknown> {
+    await this.initialize();
+    if (!this.connection) throw new Error("DuckDB connection not available");
+    if (!cacheId) throw new Error("Cannot edit utility-statement results");
+    if (!Number.isFinite(Number(rowid))) {
+      throw new Error(`Invalid rowid: ${rowid}`);
+    }
+
+    const escCol = column.replace(/"/g, '""');
+    let valExpr: string;
+    if (newValue === null || newValue === "") {
+      valExpr = "NULL";
+    } else {
+      const escVal = newValue.replace(/'/g, "''");
+      // TRY_CAST prevents bad input from raising — it returns NULL instead,
+      // and the post-update SELECT shows the user what landed in the table.
+      valExpr = `TRY_CAST('${escVal}' AS ${columnType})`;
+    }
+
+    await this.connection.run(
+      `UPDATE "${cacheId}" SET "${escCol}" = ${valExpr} WHERE rowid = ${rowid}`
+    );
+
+    // Re-read to return the actually-stored value (after the cast).
+    const reader = await this.connection.runAndReadAll(
+      `SELECT "${escCol}" AS v FROM "${cacheId}" WHERE rowid = ${rowid}`
+    );
+    const rows = reader.getRowObjectsJS();
+    if (rows.length === 0) {
+      throw new Error(`Row ${rowid} not found in cache`);
+    }
+    const stored = serializeRow(rows[0] as Record<string, unknown>, ["v"]).v;
+    return stored;
+  }
+
+  /**
+   * Write the cache table back to a source file. Uses a temp file +
+   * atomic rename so a crash mid-write can never corrupt the source.
+   */
+  async writeCacheToFile(
+    cacheId: string,
+    targetPath: string,
+    format: "parquet" | "csv" | "tsv" | "json" | "jsonl" | "ndjson"
+  ): Promise<void> {
+    await this.initialize();
+    if (!this.connection) throw new Error("DuckDB connection not available");
+    if (!cacheId) throw new Error("No cache to write back");
+
+    let copyOpts: string;
+    switch (format) {
+      case "parquet":
+        copyOpts = "(FORMAT PARQUET)";
+        break;
+      case "csv":
+        copyOpts = "(FORMAT CSV, HEADER true)";
+        break;
+      case "tsv":
+        copyOpts = "(FORMAT CSV, DELIMITER '\\t', HEADER true)";
+        break;
+      case "json":
+        copyOpts = "(FORMAT JSON, ARRAY true)";
+        break;
+      case "jsonl":
+      case "ndjson":
+        copyOpts = "(FORMAT JSON)";
+        break;
+      default:
+        throw new Error(`Unsupported write-back format: ${format}`);
+    }
+
+    const tmpPath = `${targetPath}.duckdb-vscode.tmp`;
+    const escTmp = tmpPath.replace(/'/g, "''");
+
+    // Clean up any leftover tmp from a previous failed write.
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      /* best-effort */
+    }
+
+    try {
+      // ORDER BY rowid preserves the original row order on disk.
+      await this.connection.run(
+        `COPY (SELECT * FROM "${cacheId}" ORDER BY rowid) TO '${escTmp}' ${copyOpts}`
+      );
+      // Atomic rename — the source file is never partially written.
+      fs.renameSync(tmpPath, targetPath);
+    } catch (e) {
+      try {
+        fs.rmSync(tmpPath, { force: true });
+      } catch {
+        /* best-effort */
+      }
+      throw e;
     }
   }
 

--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -324,6 +324,12 @@ export class DuckDBService {
   private connection: DuckDBConnection | null = null;
   private cacheCounter = 0;
   private activeCaches: Set<string> = new Set();
+  /**
+   * Path to the temp/spill directory we created for this process.
+   * Set only when we created it ourselves (not when the user supplied one).
+   * Removed in `dispose()` so spill files don't pile up across sessions.
+   */
+  private ownedTempDir: string | null = null;
 
   /**
    * Initialize an in-memory DuckDB database
@@ -350,11 +356,22 @@ export class DuckDBService {
     const memoryLimit = options?.memoryLimit || "1.5GB";
     await this.connection.run(`SET memory_limit = '${memoryLimit}'`);
 
-    // Use OS temp directory so spill files don't pollute the user's
-    // project and get cleaned up by the OS if the process crashes.
-    const tempDir =
-      options?.tempDirectory || path.join(os.tmpdir(), "duckdb-vscode");
-    fs.mkdirSync(tempDir, { recursive: true });
+    // Resolve the temp/spill directory.
+    //
+    // - If the user supplied one, respect it and never delete it on shutdown.
+    // - Otherwise, create a fresh per-process directory under the OS temp
+    //   root using mkdtempSync (so concurrent VS Code windows don't share
+    //   spill files), and remember it for cleanup in `dispose()`.
+    let tempDir: string;
+    if (options?.tempDirectory) {
+      tempDir = options.tempDirectory;
+      fs.mkdirSync(tempDir, { recursive: true });
+    } else {
+      const root = path.join(os.tmpdir(), "duckdb-vscode");
+      fs.mkdirSync(root, { recursive: true });
+      tempDir = fs.mkdtempSync(path.join(root, `pid-${process.pid}-`));
+      this.ownedTempDir = tempDir;
+    }
     await this.connection.run(`SET temp_directory = '${tempDir}'`);
 
     // Allow DuckDB to spill to disk when memory_limit is exceeded
@@ -365,6 +382,7 @@ export class DuckDBService {
       `🦆 DuckDB initialized (memory_limit=${memoryLimit}, temp_directory=${tempDir}, max_temp_directory_size=${maxTempSize})`
     );
   }
+
 
   /**
    * Generate a unique cache ID
@@ -1886,16 +1904,42 @@ export class DuckDBService {
   }
 
   /**
-   * Close the database connection
+   * Close the database connection and remove any spill directory we created.
+   *
+   * Cleaning the spill dir on shutdown matters because DuckDB temp files can
+   * be large (hundreds of MB to many GB once memory_limit is exceeded). If we
+   * leak them across sessions, /tmp accumulates indefinitely. Best-effort —
+   * we never throw from the shutdown path.
    */
   async close(): Promise<void> {
-    await this.dropAllCaches();
+    try {
+      await this.dropAllCaches();
+    } catch (e) {
+      console.warn("🦆 dropAllCaches failed during close:", e);
+    }
 
     if (this.connection) {
-      this.connection.closeSync();
+      try {
+        this.connection.closeSync();
+      } catch (e) {
+        console.warn("🦆 connection close failed:", e);
+      }
       this.connection = null;
     }
     this.instance = null;
+
+    if (this.ownedTempDir) {
+      try {
+        fs.rmSync(this.ownedTempDir, { recursive: true, force: true });
+        console.log(`🦆 Removed temp dir ${this.ownedTempDir}`);
+      } catch (e) {
+        console.warn(
+          `🦆 Failed to remove temp dir ${this.ownedTempDir}:`,
+          e
+        );
+      }
+      this.ownedTempDir = null;
+    }
   }
 }
 

--- a/src/services/webviewService.ts
+++ b/src/services/webviewService.ts
@@ -402,6 +402,17 @@ function setupMessageHandler(
           await handleRefreshQuery(panel, sourceId, pageSize, maxCopyRows, db);
           break;
 
+        case "runAdHoc":
+          await handleRunAdHoc(
+            panel,
+            sourceId,
+            message.sql,
+            pageSize,
+            maxCopyRows,
+            db
+          );
+          break;
+
         case "goToSource":
           await vscode.commands.executeCommand("duckdb.results.goToSource");
           break;
@@ -440,6 +451,7 @@ async function handleRequestPage(
     sortColumn?: string;
     sortDirection?: "asc" | "desc";
     whereClause?: string;
+    requestVersion?: number;
   },
   currentState: PanelState | null,
   pageSize: number,
@@ -466,6 +478,7 @@ async function handleRequestPage(
     panel.webview.postMessage({
       type: "pageData",
       data: pageData,
+      requestVersion: message.requestVersion,
     });
   } catch (error) {
     console.error("🦆 Failed to fetch page:", error);
@@ -473,6 +486,7 @@ async function handleRequestPage(
     panel.webview.postMessage({
       type: "filterError",
       cacheId,
+      requestVersion: message.requestVersion,
       error: String(error),
     });
   }
@@ -683,6 +697,56 @@ async function handleRefreshQuery(
     });
   } catch (error) {
     console.error("🦆 Failed to refresh query:", error);
+    panel.webview.postMessage({
+      type: "refreshError",
+      error: String(error),
+    });
+  }
+}
+
+/**
+ * Handle 'runAdHoc' message - execute SQL edited in the SQL modal,
+ * replacing the current results in this panel. The new SQL becomes
+ * the panel's stored query, so subsequent refreshes re-run it.
+ */
+async function handleRunAdHoc(
+  panel: vscode.WebviewPanel,
+  sourceId: string | undefined,
+  sql: unknown,
+  pageSize: number,
+  maxCopyRows: number,
+  db: ReturnType<typeof getDuckDBService>
+): Promise<void> {
+  if (typeof sql !== "string" || !sql.trim()) return;
+
+  const currentState = sourceId ? resultPanels.get(sourceId) ?? null : null;
+
+  try {
+    if (currentState) {
+      for (const cacheId of currentState.cacheIds) {
+        db.dropCache(cacheId).catch(() => {});
+      }
+    }
+
+    const result = await db.executeQuery(sql, pageSize);
+
+    if (currentState) {
+      const newCacheIds = collectCacheIds(result);
+      currentState.cacheIds = newCacheIds;
+      currentState.currentResult = result;
+      currentState.sortColumn = undefined;
+      currentState.sortDirection = undefined;
+      currentState.queries = result.statements.map((s) => s.meta.sql);
+      panel.title = buildPanelTitle(result);
+    }
+
+    panel.webview.postMessage({
+      type: "queryResult",
+      data: result,
+      pageSize,
+      maxCopyRows,
+    });
+  } catch (error) {
     panel.webview.postMessage({
       type: "refreshError",
       error: String(error),

--- a/src/webview/FileOverview.tsx
+++ b/src/webview/FileOverview.tsx
@@ -235,13 +235,19 @@ export function FileOverview({ metadata, onBackToContainer }: FileOverviewProps)
     });
   }, [selectedColumnNames, noneSelected]);
 
-  const handleOpenAsSql = useCallback(() => {
+  const handleOpenAsSql = useCallback((sql?: string) => {
     const vscode = getVscodeApi();
     vscode.postMessage({
       type: 'openAsSql',
       columns: selectedColumnNames,
+      sql,
     });
   }, [selectedColumnNames]);
+
+  const handleRunAdHoc = useCallback((sql: string) => {
+    const vscode = getVscodeApi();
+    vscode.postMessage({ type: 'runAdHoc', sql });
+  }, []);
 
   const handleCopySql = useCallback((text: string) => {
     navigator.clipboard.writeText(text);
@@ -445,13 +451,14 @@ export function FileOverview({ metadata, onBackToContainer }: FileOverviewProps)
         </code>
       </div>
 
-      {/* SQL Modal — shared with ResultsTable */}
+      {/* SQL Modal — editable; ⌘↵ runs the (possibly modified) query */}
       {showSqlModal && (
         <SqlModal
           sql={sqlPreview}
           onClose={() => setShowSqlModal(false)}
           onCopy={handleCopySql}
           onOpenInEditor={handleOpenAsSql}
+          onRun={handleRunAdHoc}
           title="SQL Preview"
         />
       )}

--- a/src/webview/QueryPanel.tsx
+++ b/src/webview/QueryPanel.tsx
@@ -17,6 +17,8 @@ interface QueryPanelProps {
   result: MultiQueryResultWithPages;
   pageSize: number;
   maxCopyRows: number;
+  /** When true, cell-edit-with-save is enabled in the results table. */
+  editable?: boolean;
   onBackToOverview?: () => void;
 }
 
@@ -24,11 +26,13 @@ interface QueryPanelProps {
  * QueryPanel - Top-level component for displaying query results
  * Handles the distinction between single and multi-statement results
  */
-export function QueryPanel({ result, pageSize, maxCopyRows, onBackToOverview }: QueryPanelProps) {
-  // For multi-statement with more than one statement, render collapsible container
+export function QueryPanel({ result, pageSize, maxCopyRows, editable = false, onBackToOverview }: QueryPanelProps) {
+  // For multi-statement with more than one statement, render collapsible container.
+  // Multi-statement is never editable (we don't track which cache the edit
+  // belongs to per-statement).
   if (result.statements.length > 1) {
     return (
-      <MultiStatementContainer 
+      <MultiStatementContainer
         statements={result.statements}
         totalExecutionTime={result.totalExecutionTime}
         pageSize={pageSize}
@@ -36,13 +40,13 @@ export function QueryPanel({ result, pageSize, maxCopyRows, onBackToOverview }: 
       />
     );
   }
-  
+
   // Single statement - render directly (always expanded, not collapsible)
   const stmt = result.statements[0];
   if (!stmt) {
     return <div className="empty-state">No results</div>;
   }
-  
+
   return (
     <>
       {onBackToOverview && (
@@ -58,6 +62,7 @@ export function QueryPanel({ result, pageSize, maxCopyRows, onBackToOverview }: 
         initialPage={stmt.page}
         pageSize={pageSize}
         maxCopyRows={maxCopyRows}
+        editable={editable}
         hasResults={stmt.meta.hasResults}
         isCollapsible={false}
         isExpanded={true}

--- a/src/webview/ResultsTable.tsx
+++ b/src/webview/ResultsTable.tsx
@@ -52,6 +52,12 @@ export interface ResultsTableProps {
   /** Chunk size used for virtualized fetches. Server returns pages of this size. */
   pageSize: number;
   maxCopyRows: number;
+  /**
+   * When true, the cell expansion modal exposes a Save button that persists
+   * edits back to the source. Only set by the host when the cache is the
+   * full unbounded source and the format supports DuckDB COPY write-back.
+   */
+  editable?: boolean;
   hasResults?: boolean;
   statementIndex?: number;
   totalStatements?: number;
@@ -68,6 +74,7 @@ export function ResultsTable({
   initialPage,
   pageSize,
   maxCopyRows,
+  editable = false,
   hasResults = true,
   statementIndex,
   totalStatements,
@@ -75,7 +82,7 @@ export function ResultsTable({
   isExpanded = true,
   onToggleExpand,
 }: ResultsTableProps) {
-  const { cacheId, sql, columns, totalRows, executionTime } = meta;
+  const { cacheId, sql, columns, columnTypes, totalRows, executionTime } = meta;
 
   // ---- Sort / filter state ----
   const [sort, setSort] = useState<{ column: string | null; direction: SortDirection }>({
@@ -129,8 +136,35 @@ export function ResultsTable({
   // ---- Misc UI state ----
   const [showSqlModal, setShowSqlModal] = useState(false);
   const [showFullSqlModal, setShowFullSqlModal] = useState(false);
+  /**
+   * Column widths. Keyed by column name. The synthetic key `__rownum__`
+   * holds the user-overridden width of the row-number gutter; if absent,
+   * the gutter falls back to a digit-derived default.
+   */
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
-  const [expandedCell, setExpandedCell] = useState<{ value: unknown; column: string } | null>(null);
+  /**
+   * The cell currently shown in the expansion / edit modal. When `editable`
+   * is true and this cell's row is cached (so we have a __rowid), the modal
+   * exposes a Save button.
+   */
+  const [expandedCell, setExpandedCell] = useState<{
+    value: unknown;
+    column: string;
+    columnType: string;
+    rowIndex: number;
+    colIndex: number;
+    rowId: number | null;
+  } | null>(null);
+  /**
+   * In-flight cell save. Wires the modal's "Saving…" state and routes the
+   * `cellUpdated` response back to the right column for cache patching.
+   */
+  const [cellSave, setCellSave] = useState<{
+    rowId: number;
+    column: string;
+    columnType: string;
+  } | null>(null);
+  const [cellSaveError, setCellSaveError] = useState<string | null>(null);
 
   // Selection state — uses ABSOLUTE row indexes (over the full filtered result set).
   interface CellPosition { row: number; col: number; }
@@ -404,11 +438,47 @@ export function ResultsTable({
       } else if (message.type === 'refreshError') {
         setIsRefreshing(false);
         toast.show(message.error || 'Refresh failed');
+      } else if (message.type === 'cellUpdated') {
+        // Match against in-flight cell save by rowId+column.
+        if (
+          !cellSave ||
+          message.rowId !== cellSave.rowId ||
+          message.column !== cellSave.column
+        ) return;
+        if (message.error) {
+          setCellSaveError(message.error);
+          setCellSave(null);
+          return;
+        }
+        // Patch the cached chunk so the table reflects the new value
+        // immediately, without round-tripping a fresh fetch.
+        setChunks((prev) => {
+          const next = new Map(prev);
+          for (const [chunkIdx, rows] of next) {
+            for (let i = 0; i < rows.length; i++) {
+              const r = rows[i] as Record<string, unknown>;
+              const rid = r.__rowid;
+              const ridNum = typeof rid === 'bigint' ? Number(rid) : (typeof rid === 'number' ? rid : null);
+              if (ridNum === message.rowId) {
+                const updated = { ...r, [message.column]: message.newValue };
+                const newRows = rows.slice();
+                newRows[i] = updated;
+                next.set(chunkIdx, newRows);
+                return next;
+              }
+            }
+          }
+          return next;
+        });
+        setCellSave(null);
+        setCellSaveError(null);
+        setExpandedCell(null);
+        toast.show('Cell saved');
       }
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [cacheId, pageSize, renderStart, renderEnd, toast]);
+  }, [cacheId, pageSize, renderStart, renderEnd, toast, cellSave]);
 
   // --------------------------------------------------------------------------
   // Sort / filter handlers — all converge on resetAndReload.
@@ -520,6 +590,29 @@ export function ResultsTable({
     setColumnWidths((prev) => ({ ...prev, [column]: Math.max(50, width) }));
   }, []);
 
+  /**
+   * Row-number gutter width. Default scales with the digit count of the
+   * largest visible row index so values like `10,000,000` don't clip.
+   * Overridden when the user drags the gutter's resize handle.
+   */
+  const ROW_NUMBER_KEY = '__rownum__';
+  const rowNumberWidth = useMemo(() => {
+    if (columnWidths[ROW_NUMBER_KEY]) return columnWidths[ROW_NUMBER_KEY];
+    // (filteredRowCount).toLocaleString() length × ~7px monospace + padding.
+    const digits = Math.max(1, String(Math.max(filteredRowCount, 1)).length);
+    const commas = Math.max(0, Math.floor((digits - 1) / 3));
+    return Math.max(50, (digits + commas) * 8 + 20);
+  }, [columnWidths, filteredRowCount]);
+  const rowNumberStyle: React.CSSProperties = {
+    width: rowNumberWidth,
+    minWidth: rowNumberWidth,
+    maxWidth: rowNumberWidth,
+  };
+  const handleRowNumberResize = useCallback(
+    (width: number) => handleColumnResize(ROW_NUMBER_KEY, width),
+    [handleColumnResize]
+  );
+
   const copyToClipboard = useCallback(async (text: string, label: string) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -605,8 +698,43 @@ export function ResultsTable({
     const row = lookupRow(rowIdx);
     if (!row) return;
     const col = columns[colIdx];
-    setExpandedCell({ value: row[col], column: col });
-  }, [lookupRow, columns]);
+    // __rowid is injected by the server (fetchPage) so the modal can edit
+    // the right row regardless of the active sort / filter context.
+    const rid = (row as Record<string, unknown>).__rowid;
+    const rowId = typeof rid === 'bigint' ? Number(rid) : (typeof rid === 'number' ? rid : null);
+    setExpandedCell({
+      value: row[col],
+      column: col,
+      columnType: columnTypes[colIdx] || 'VARCHAR',
+      rowIndex: rowIdx,
+      colIndex: colIdx,
+      rowId,
+    });
+    setCellSaveError(null);
+  }, [lookupRow, columns, columnTypes]);
+
+  /**
+   * Save handler for the cell modal. Posts updateCell to the host, leaving
+   * the modal in a saving state until the matching cellUpdated response
+   * arrives in the message effect below.
+   */
+  const handleCellSave = useCallback((newValue: string | null) => {
+    if (!expandedCell || expandedCell.rowId === null) return;
+    setCellSave({
+      rowId: expandedCell.rowId,
+      column: expandedCell.column,
+      columnType: expandedCell.columnType,
+    });
+    setCellSaveError(null);
+    getVscodeApi()?.postMessage({
+      type: 'updateCell',
+      cacheId,
+      rowId: expandedCell.rowId,
+      column: expandedCell.column,
+      columnType: expandedCell.columnType,
+      newValue,
+    });
+  }, [expandedCell, cacheId]);
 
   const handleRowSelect = useCallback((rowIdx: number, e: React.MouseEvent) => {
     if (e.shiftKey && selection) {
@@ -783,8 +911,17 @@ export function ResultsTable({
         <CellExpansionModal
           value={expandedCell.value}
           column={expandedCell.column}
-          onClose={() => setExpandedCell(null)}
+          columnType={expandedCell.columnType}
+          canEdit={editable && expandedCell.rowId !== null}
+          isSaving={cellSave !== null}
+          saveError={cellSaveError}
+          onClose={() => {
+            if (cellSave) return; // don't close while a save is in flight
+            setExpandedCell(null);
+            setCellSaveError(null);
+          }}
           onCopy={(text) => copyToClipboard(text, 'cell')}
+          onSave={handleCellSave}
         />
       )}
 
@@ -938,7 +1075,7 @@ export function ResultsTable({
             <table>
               <thead>
                 <tr>
-                  <th className="row-number-header">#</th>
+                  <RowNumberHeader width={rowNumberWidth} onResize={handleRowNumberResize} />
                   {columns.map((col, idx) => (
                     <th key={idx}>
                       <div className="th-content">
@@ -984,7 +1121,7 @@ export function ResultsTable({
           <table>
             <thead>
               <tr ref={headerRowRef}>
-                <th className="row-number-header">#</th>
+                <RowNumberHeader width={rowNumberWidth} onResize={handleRowNumberResize} />
                 {columns.map((col, idx) => {
                   const hasFilter = filterState.filters.some((f) => f.column === col);
                   return (
@@ -1022,7 +1159,7 @@ export function ResultsTable({
                       ref={isFirst ? firstRenderedRowRef : null}
                       className="virt-row virt-row-loading"
                     >
-                      <td className="row-number">{index + 1}</td>
+                      <td className="row-number" style={rowNumberStyle}>{(index + 1).toLocaleString()}</td>
                       {columns.map((col, colIdx) => (
                         <td key={colIdx} className="cell-loading">
                           <span className="cell-skeleton" />
@@ -1037,8 +1174,12 @@ export function ResultsTable({
                     ref={isFirst ? firstRenderedRowRef : null}
                     className={`virt-row ${rowSel ? 'row-selected' : ''}`}
                   >
-                    <td className="row-number" onClick={(e) => handleRowSelect(index, e)}>
-                      {index + 1}
+                    <td
+                      className="row-number"
+                      style={rowNumberStyle}
+                      onClick={(e) => handleRowSelect(index, e)}
+                    >
+                      {(index + 1).toLocaleString()}
                     </td>
                     {columns.map((col, colIdx) => (
                       <td
@@ -1103,6 +1244,62 @@ export function ResultsTable({
 // ============================================================================
 // HELPER COMPONENTS
 // ============================================================================
+
+/**
+ * Resize-handle drag logic shared by ResizableHeader and RowNumberHeader.
+ * Returns the mousedown handler to wire on the handle element.
+ */
+function useResizeHandle(
+  thRef: React.RefObject<HTMLTableCellElement | null>,
+  onResize: (width: number) => void,
+  onResizingChange?: (resizing: boolean) => void
+) {
+  return useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const startX = e.clientX;
+      const startWidth = thRef.current?.offsetWidth || 100;
+      const handleMouseMove = (ev: MouseEvent) => {
+        const delta = ev.clientX - startX;
+        onResize(startWidth + delta);
+      };
+      const handleMouseUp = () => {
+        onResizingChange?.(false);
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+      onResizingChange?.(true);
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [thRef, onResize, onResizingChange]
+  );
+}
+
+interface RowNumberHeaderProps {
+  width: number;
+  onResize: (width: number) => void;
+}
+
+function RowNumberHeader({ width, onResize }: RowNumberHeaderProps) {
+  const thRef = useRef<HTMLTableCellElement>(null);
+  const handleMouseDown = useResizeHandle(thRef, onResize);
+  return (
+    <th
+      ref={thRef}
+      className="row-number-header"
+      style={{ width, minWidth: width, maxWidth: width }}
+    >
+      #
+      <div className="resize-handle" onMouseDown={handleMouseDown} />
+    </th>
+  );
+}
 
 interface ResizableHeaderProps {
   column: string;
@@ -1181,49 +1378,144 @@ function ResizableHeader({ column, width, isSorted, sortDirection, isSelected, h
 interface CellExpansionModalProps {
   value: unknown;
   column: string;
+  columnType?: string;
+  /** When true, the modal becomes an editor with a Save button. */
+  canEdit?: boolean;
+  /** True while the host is processing the save (Save button shows a spinner). */
+  isSaving?: boolean;
+  /** Last save error from the host; cleared by editing the value again. */
+  saveError?: string | null;
   onClose: () => void;
   onCopy: (text: string) => void;
+  /** Persist the new value. `null` represents NULL (empty input). */
+  onSave?: (newValue: string | null) => void;
 }
 
-function CellExpansionModal({ value, column, onClose, onCopy }: CellExpansionModalProps) {
+function CellExpansionModal({
+  value,
+  column,
+  columnType,
+  canEdit = false,
+  isSaving = false,
+  saveError = null,
+  onClose,
+  onCopy,
+  onSave,
+}: CellExpansionModalProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // The original value rendered as a string. NULL is shown as the empty
+  // string while editing (so the user can clear a cell to NULL by emptying
+  // it and saving), but as the literal "NULL" when read-only.
+  const isNull = value === null || value === undefined;
+  const isJson = typeof value === 'object' && value !== null;
+
   const displayText = useMemo(() => {
-    if (value === null || value === undefined) return 'NULL';
-    if (typeof value === 'object') {
+    if (isNull) return 'NULL';
+    if (isJson) {
       try { return JSON.stringify(value, null, 2); } catch { return String(value); }
     }
     return String(value);
-  }, [value]);
+  }, [value, isNull, isJson]);
 
-  const isJson = typeof value === 'object' && value !== null;
+  const initialDraft = useMemo(() => {
+    if (isNull) return '';
+    if (isJson) {
+      try { return JSON.stringify(value, null, 2); } catch { return String(value); }
+    }
+    return String(value);
+  }, [value, isNull, isJson]);
+
+  const [draft, setDraft] = useState(initialDraft);
+  // Reset the draft when the underlying cell changes (e.g., user opens a different cell).
+  useEffect(() => { setDraft(initialDraft); }, [initialDraft]);
+
+  // Complex types (LIST, STRUCT, MAP) — TRY_CAST won't reliably reverse the
+  // JSON representation, so editing them in v1 is opt-out.
+  const isComplexType = !!columnType && /^(LIST|STRUCT|MAP|UNION)/i.test(columnType.trim());
+  const editable = canEdit && !!onSave && !isComplexType;
+  const isDirty = editable && draft !== initialDraft;
 
   useEffect(() => {
     if (!isJson) {
       textareaRef.current?.focus();
-      textareaRef.current?.select();
+      if (!editable) textareaRef.current?.select();
     }
-  }, [isJson]);
+  }, [isJson, editable]);
+
+  const handleSave = useCallback(() => {
+    if (!editable || !onSave || !isDirty || isSaving) return;
+    // Empty draft => NULL; otherwise pass the raw string for server-side cast.
+    onSave(draft === '' ? null : draft);
+  }, [editable, onSave, isDirty, isSaving, draft]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (editable && (e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleSave();
+    }
+  }, [editable, handleSave]);
 
   const title = (
     <>
       <span className="modal-column">{column}</span>
-      {isJson && <span className="modal-type">JSON</span>}
+      {columnType && <span className="modal-type">{columnType}</span>}
     </>
   );
+
+  const hint = isSaving
+    ? 'Saving…'
+    : !editable && canEdit && isComplexType
+    ? `Editing ${columnType ?? 'complex'} cells is not supported yet — read-only.`
+    : !canEdit
+    ? 'Read-only — file format does not support write-back, or this is a derived/limited result.'
+    : 'Edit and press ⌘↵ to save · Esc to close';
+
+  // Custom modal action: Save button (only when editable).
+  const actions = editable
+    ? [{
+        icon: isSaving ? <span className="cell-modal-spinner" /> : <span>💾</span>,
+        label: isSaving ? 'Saving…' : (isDirty ? 'Save (⌘↵)' : 'Save'),
+        onClick: handleSave,
+      }]
+    : undefined;
 
   return (
     <Modal
       title={title}
       onClose={onClose}
-      onCopy={() => onCopy(displayText)}
-      hint="Select text and ⌘C to copy, or click Copy button"
-      size={`${displayText.length.toLocaleString()} chars`}
+      onCopy={() => onCopy(editable ? draft : displayText)}
+      hint={hint}
+      size={`${(editable ? draft : displayText).length.toLocaleString()} chars`}
+      actions={actions}
     >
-      {isJson ? (
+      {editable ? (
+        <textarea
+          ref={textareaRef}
+          className="modal-content modal-cell-editor"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+          disabled={isSaving}
+          placeholder="(empty = NULL)"
+        />
+      ) : isJson ? (
         <pre className="modal-content modal-json"><JsonSyntaxHighlight json={displayText} /></pre>
       ) : (
-        <textarea ref={textareaRef} className="modal-content" value={displayText} readOnly spellCheck={false} />
+        <textarea
+          ref={textareaRef}
+          className="modal-content"
+          value={displayText}
+          readOnly
+          spellCheck={false}
+        />
+      )}
+      {saveError && (
+        <div className="cell-modal-error">
+          <span className="cell-modal-error-icon">⚠</span>
+          <span>{saveError}</span>
+        </div>
       )}
     </Modal>
   );

--- a/src/webview/ResultsTable.tsx
+++ b/src/webview/ResultsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import type { ColumnStats, StatementCacheMeta, PageData } from './types';
 import { ColumnsPanel } from './ColumnsPanel';
 import { Modal } from './ui/Modal';
@@ -6,13 +6,12 @@ import { SqlModal } from './ui/SqlModal';
 import { JsonSyntaxHighlight } from './ui/JsonHighlight';
 import { CellValue } from './ui/CellValue';
 import { SqlPreview } from './ui/SqlHighlight';
-import { 
-  FilterBar, 
-  FilterState, 
-  ColumnFilter, 
-  createInitialFilterState, 
+import {
+  FilterBar,
+  FilterState,
+  ColumnFilter,
+  createInitialFilterState,
   filtersToWhereClause,
-  generateFilterId 
 } from './ui/FilterBar';
 import { ColumnFilterPopover } from './ui/ColumnFilterPopover';
 import { formatValue, formatTableAsText } from './utils/format';
@@ -30,12 +29,27 @@ function getVscodeApi() {
 }
 
 // ============================================================================
+// VIRTUALIZATION CONSTANTS
+// ============================================================================
+
+/** Initial row-height guess; replaced by measurement after first paint. */
+const DEFAULT_ROW_HEIGHT = 33;
+/** Rows rendered above/below the visible viewport for smooth scrolling. */
+const OVERSCAN_ROWS = 40;
+/**
+ * Max chunks held in the in-memory row cache. Older/farther chunks are
+ * evicted when this is exceeded. 80 chunks * 100 rows ≈ 8k rows resident.
+ */
+const MAX_CACHED_CHUNKS = 80;
+
+// ============================================================================
 // RESULTS TABLE - Display component for a single statement's results
 // ============================================================================
 
 export interface ResultsTableProps {
   meta: StatementCacheMeta;
   initialPage: PageData;
+  /** Chunk size used for virtualized fetches. Server returns pages of this size. */
   pageSize: number;
   maxCopyRows: number;
   hasResults?: boolean;
@@ -46,6 +60,8 @@ export interface ResultsTableProps {
   isExpanded?: boolean;
   onToggleExpand?: () => void;
 }
+
+type SortDirection = 'asc' | 'desc' | null;
 
 export function ResultsTable({
   meta,
@@ -60,54 +76,12 @@ export function ResultsTable({
   onToggleExpand,
 }: ResultsTableProps) {
   const { cacheId, sql, columns, totalRows, executionTime } = meta;
-  
-  // Current page data
-  const [currentPage, setCurrentPage] = useState<PageData>(initialPage);
-  const [isLoadingPage, setIsLoadingPage] = useState(false);
-  
-  // Sorting state (server-side)
-  type SortDirection = 'asc' | 'desc' | null;
-  const [sort, setSort] = useState<{ column: string | null; direction: SortDirection }>({ 
-    column: initialPage.sortColumn || null, 
-    direction: initialPage.sortDirection || null 
+
+  // ---- Sort / filter state ----
+  const [sort, setSort] = useState<{ column: string | null; direction: SortDirection }>({
+    column: initialPage.sortColumn || null,
+    direction: initialPage.sortDirection || null,
   });
-  
-  // SQL modal state
-  const [showSqlModal, setShowSqlModal] = useState(false);
-  const [showFullSqlModal, setShowFullSqlModal] = useState(false);
-  
-  // Column widths state
-  const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
-  
-  // Selection state
-  interface CellPosition { row: number; col: number; }
-  interface Selection { start: CellPosition; end: CellPosition; }
-  const [selection, setSelection] = useState<Selection | null>(null);
-  
-  // Toast notification
-  const toast = useToast();
-  
-  // Cell expansion modal
-  const [expandedCell, setExpandedCell] = useState<{ value: unknown; column: string } | null>(null);
-  
-  
-  // Columns panel - default to 35% of window width, min 320, max 800
-  const [showColumnsPanel, setShowColumnsPanel] = useState(false);
-  const [columnsPanelWidth, setColumnsPanelWidth] = useState(() => {
-    const maxWidth = Math.min(800, Math.floor(window.innerWidth * 0.5));
-    return Math.max(320, Math.min(maxWidth, Math.floor(window.innerWidth * 0.35)));
-  });
-  const [initialExpandedColumn, setInitialExpandedColumn] = useState<string | null>(null);
-  const [columnStatsMap, setColumnStatsMap] = useState<Record<string, ColumnStats | null>>({});
-  const [loadingStatsColumn, setLoadingStatsColumn] = useState<string | null>(null);
-  const [statsError, setStatsError] = useState<string | null>(null);
-  
-  // Column summaries (from server via SUMMARIZE)
-  const [columnSummaries, setColumnSummaries] = useState<Array<{name: string; distinctCount: number; nullPercent: number; inferredType: string}>>([]);
-  const [loadingSummaries, setLoadingSummaries] = useState(false);
-  const [summariesLoaded, setSummariesLoaded] = useState(false);
-  
-  // Filter state
   const [filterState, setFilterState] = useState<FilterState>(createInitialFilterState());
   const [filteredRowCount, setFilteredRowCount] = useState<number>(totalRows);
   const [filterPopover, setFilterPopover] = useState<{
@@ -118,19 +92,77 @@ export function ResultsTable({
   const [distinctValues, setDistinctValues] = useState<{ value: string; count: number }[]>([]);
   const [columnCardinality, setColumnCardinality] = useState<number>(0);
   const [loadingDistinct, setLoadingDistinct] = useState(false);
-  
-  // Copy loading state
-  const [copyLoading, setCopyLoading] = useState(false);
-  
-  // Refresh state
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  
-  // Table wrapper ref
-  const tableWrapperRef = useRef<HTMLDivElement>(null);
 
-  // Reset state when switching statements (cacheId changes)
+  // ---- Virtualized chunk cache ----
+  // Map<chunkIndex, rows[]> — chunk i covers rows [i*pageSize .. i*pageSize + pageSize - 1].
+  const [chunks, setChunks] = useState<Map<number, Record<string, unknown>[]>>(() => {
+    const m = new Map<number, Record<string, unknown>[]>();
+    if (initialPage.rows.length > 0) {
+      // Server may return more than one chunk's worth in initialPage; split.
+      for (let i = 0; i < initialPage.rows.length; i += pageSize) {
+        const idx = Math.floor((initialPage.offset + i) / pageSize);
+        m.set(idx, initialPage.rows.slice(i, i + pageSize));
+      }
+    }
+    return m;
+  });
+  /** Set of chunk indexes with an in-flight fetch (avoids duplicate requests). */
+  const pendingChunks = useRef<Set<number>>(new Set());
+  /** LRU access timestamps per chunk, for eviction. */
+  const chunkAccess = useRef<Map<number, number>>(new Map());
+  /**
+   * Bumped on every sort/filter/cacheId reset. Echoed in pageData responses
+   * so we drop stale chunks from prior queries (e.g. response for old sort
+   * landing after the user has already changed sort).
+   */
+  const cacheVersion = useRef(0);
+
+  // ---- Scroll viewport state ----
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(600);
+  const [rowHeight, setRowHeight] = useState(DEFAULT_ROW_HEIGHT);
+  const tableWrapperRef = useRef<HTMLDivElement>(null);
+  const firstRenderedRowRef = useRef<HTMLTableRowElement>(null);
+  const headerRowRef = useRef<HTMLTableRowElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  // ---- Misc UI state ----
+  const [showSqlModal, setShowSqlModal] = useState(false);
+  const [showFullSqlModal, setShowFullSqlModal] = useState(false);
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+  const [expandedCell, setExpandedCell] = useState<{ value: unknown; column: string } | null>(null);
+
+  // Selection state — uses ABSOLUTE row indexes (over the full filtered result set).
+  interface CellPosition { row: number; col: number; }
+  interface Selection { start: CellPosition; end: CellPosition; }
+  const [selection, setSelection] = useState<Selection | null>(null);
+
+  const toast = useToast();
+
+  // ---- Columns panel ----
+  const [showColumnsPanel, setShowColumnsPanel] = useState(false);
+  const [columnsPanelWidth, setColumnsPanelWidth] = useState(() => {
+    const maxWidth = Math.min(800, Math.floor(window.innerWidth * 0.5));
+    return Math.max(320, Math.min(maxWidth, Math.floor(window.innerWidth * 0.35)));
+  });
+  const [initialExpandedColumn, setInitialExpandedColumn] = useState<string | null>(null);
+  const [columnStatsMap, setColumnStatsMap] = useState<Record<string, ColumnStats | null>>({});
+  const [loadingStatsColumn, setLoadingStatsColumn] = useState<string | null>(null);
+  const [statsError, setStatsError] = useState<string | null>(null);
+  const [columnSummaries, setColumnSummaries] = useState<Array<{ name: string; distinctCount: number; nullPercent: number; inferredType: string }>>([]);
+  const [loadingSummaries, setLoadingSummaries] = useState(false);
+  const [summariesLoaded, setSummariesLoaded] = useState(false);
+
+  const [copyLoading, setCopyLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // --------------------------------------------------------------------------
+  // Effect: reset everything when the underlying query changes (cacheId).
+  // --------------------------------------------------------------------------
   useEffect(() => {
-    // Reset column stats
+    cacheVersion.current++;
+    pendingChunks.current.clear();
+    chunkAccess.current.clear();
     setColumnStatsMap({});
     setColumnSummaries([]);
     setSummariesLoaded(false);
@@ -138,54 +170,206 @@ export function ResultsTable({
     setStatsError(null);
     setShowColumnsPanel(false);
     setInitialExpandedColumn(null);
-    // Reset filters - old filters won't apply to new query columns
     setFilterState(createInitialFilterState());
     setFilteredRowCount(totalRows);
     setDistinctValues([]);
     setColumnCardinality(0);
     setFilterPopover(null);
-    // Reset refresh state
     setIsRefreshing(false);
+    setSelection(null);
+    setScrollTop(0);
+    if (tableWrapperRef.current) tableWrapperRef.current.scrollTop = 0;
+  }, [cacheId, totalRows]);
+
+  // --------------------------------------------------------------------------
+  // Effect: when initialPage changes (refresh / new query), seed cache.
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const m = new Map<number, Record<string, unknown>[]>();
+    if (initialPage.rows.length > 0) {
+      for (let i = 0; i < initialPage.rows.length; i += pageSize) {
+        const idx = Math.floor((initialPage.offset + i) / pageSize);
+        m.set(idx, initialPage.rows.slice(i, i + pageSize));
+        chunkAccess.current.set(idx, Date.now());
+      }
+    }
+    setChunks(m);
+    setSort({
+      column: initialPage.sortColumn || null,
+      direction: initialPage.sortDirection || null,
+    });
+  }, [initialPage, pageSize]);
+
+  // --------------------------------------------------------------------------
+  // Scroll + resize tracking.
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const el = tableWrapperRef.current;
+    if (!el) return;
+
+    let raf = 0;
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        setScrollTop(el.scrollTop);
+      });
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+
+    const ro = 'ResizeObserver' in window
+      ? new ResizeObserver(() => setViewportHeight(el.clientHeight))
+      : null;
+    ro?.observe(el);
+    setViewportHeight(el.clientHeight);
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      ro?.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, [cacheId]);
 
-  // Pagination helpers
-  const currentOffset = currentPage.offset;
-  const currentPageNum = Math.floor(currentOffset / pageSize) + 1;
-  const totalPages = Math.ceil(totalRows / pageSize);
-  const displayRows = currentPage.rows;
+  // Measure row + header height after first paint to keep math accurate.
+  useLayoutEffect(() => {
+    if (headerRowRef.current) {
+      const h = headerRowRef.current.offsetHeight;
+      if (h > 0 && Math.abs(h - headerHeight) > 0.5) setHeaderHeight(h);
+    }
+    if (firstRenderedRowRef.current) {
+      const h = firstRenderedRowRef.current.offsetHeight;
+      if (h > 0 && Math.abs(h - rowHeight) > 0.5) setRowHeight(h);
+    }
+  });
 
-  // Update page when initialPage changes (new query)
+  // --------------------------------------------------------------------------
+  // Compute the visible row range and which chunks back it.
+  // --------------------------------------------------------------------------
+  const visibleHeight = Math.max(0, viewportHeight - headerHeight);
+  const firstVisible = Math.max(0, Math.floor(scrollTop / rowHeight));
+  const lastVisible = Math.min(filteredRowCount, Math.ceil((scrollTop + visibleHeight) / rowHeight));
+  const renderStart = Math.max(0, firstVisible - OVERSCAN_ROWS);
+  const renderEnd = Math.min(filteredRowCount, lastVisible + OVERSCAN_ROWS);
+  const topSpacerHeight = renderStart * rowHeight;
+  const bottomSpacerHeight = Math.max(0, (filteredRowCount - renderEnd) * rowHeight);
+
+  // --------------------------------------------------------------------------
+  // Helper: build the active where clause from filter state.
+  // --------------------------------------------------------------------------
+  const getActiveWhereClause = useCallback((): string => {
+    if (filterState.isPaused) return '';
+    return filtersToWhereClause(filterState.filters);
+  }, [filterState]);
+
+  // --------------------------------------------------------------------------
+  // Fetch a single chunk by index. Used both for fill-in during scroll and
+  // for a fresh load after sort/filter reset (chunkIdx=0 after clearing).
+  // --------------------------------------------------------------------------
+  const fetchChunk = useCallback(
+    (chunkIdx: number, opts?: { sortColumn?: string | null; sortDirection?: SortDirection; whereClause?: string }) => {
+      if (!cacheId) return;
+      if (pendingChunks.current.has(chunkIdx)) return;
+      pendingChunks.current.add(chunkIdx);
+      const vscode = getVscodeApi();
+      vscode?.postMessage({
+        type: 'requestPage',
+        cacheId,
+        offset: chunkIdx * pageSize,
+        sortColumn: opts?.sortColumn ?? sort.column ?? undefined,
+        sortDirection: opts?.sortDirection ?? sort.direction ?? undefined,
+        whereClause: opts?.whereClause ?? getActiveWhereClause(),
+        requestVersion: cacheVersion.current,
+      });
+    },
+    [cacheId, pageSize, sort, getActiveWhereClause]
+  );
+
+  // --------------------------------------------------------------------------
+  // Trigger fetches for chunks intersecting the visible window.
+  // --------------------------------------------------------------------------
   useEffect(() => {
-    setCurrentPage(initialPage);
-    setSort({ 
-      column: initialPage.sortColumn || null, 
-      direction: initialPage.sortDirection || null 
-    });
-    setSelection(null);
-  }, [initialPage]);
+    if (!cacheId || filteredRowCount === 0) return;
+    const firstChunk = Math.floor(renderStart / pageSize);
+    const lastChunk = Math.floor(Math.max(renderStart, renderEnd - 1) / pageSize);
+    for (let c = firstChunk; c <= lastChunk; c++) {
+      if (!chunks.has(c) && !pendingChunks.current.has(c)) {
+        fetchChunk(c);
+      }
+    }
+  }, [renderStart, renderEnd, chunks, fetchChunk, cacheId, filteredRowCount, pageSize]);
 
-  // Listen for page data and other messages
+  // --------------------------------------------------------------------------
+  // Reset cache, scroll, and refetch chunk 0 — used when sort/filter changes.
+  // --------------------------------------------------------------------------
+  const resetAndReload = useCallback(
+    (sortColumn: string | null, sortDirection: SortDirection, whereClause: string) => {
+      cacheVersion.current++;
+      pendingChunks.current.clear();
+      chunkAccess.current.clear();
+      setChunks(new Map());
+      setSelection(null);
+      if (tableWrapperRef.current) tableWrapperRef.current.scrollTop = 0;
+      setScrollTop(0);
+      // Fetch the first chunk immediately; the visible-range effect will
+      // request additional chunks once the response arrives.
+      fetchChunk(0, { sortColumn, sortDirection, whereClause });
+    },
+    [fetchChunk]
+  );
+
+  // --------------------------------------------------------------------------
+  // Message handler — wire up incoming pageData / column stats / etc.
+  // --------------------------------------------------------------------------
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data;
+
       if (message.type === 'pageData' && message.data?.cacheId === cacheId) {
-        setCurrentPage(message.data);
-        setFilteredRowCount(message.data.totalRows);
-        setIsLoadingPage(false);
-        setSelection(null);
+        // Drop stale responses from a prior cacheVersion (sort/filter changed).
+        if (
+          typeof message.requestVersion === 'number' &&
+          message.requestVersion !== cacheVersion.current
+        ) {
+          return;
+        }
+        const data = message.data as PageData;
+        const chunkIdx = Math.floor(data.offset / pageSize);
+        pendingChunks.current.delete(chunkIdx);
+
+        setFilteredRowCount(data.totalRows);
+        setChunks((prev) => {
+          const next = new Map(prev);
+          next.set(chunkIdx, data.rows);
+          chunkAccess.current.set(chunkIdx, Date.now());
+          // LRU eviction: keep only the MAX_CACHED_CHUNKS most-recently-used,
+          // but never evict chunks currently in the visible render window.
+          if (next.size > MAX_CACHED_CHUNKS) {
+            const visibleFirst = Math.floor(renderStart / pageSize);
+            const visibleLast = Math.floor(Math.max(renderStart, renderEnd - 1) / pageSize);
+            const candidates = [...next.keys()].filter(
+              (k) => k < visibleFirst || k > visibleLast
+            );
+            candidates.sort((a, b) => {
+              const ta = chunkAccess.current.get(a) ?? 0;
+              const tb = chunkAccess.current.get(b) ?? 0;
+              return ta - tb;
+            });
+            const excess = next.size - MAX_CACHED_CHUNKS;
+            for (let i = 0; i < excess && i < candidates.length; i++) {
+              next.delete(candidates[i]);
+              chunkAccess.current.delete(candidates[i]);
+            }
+          }
+          return next;
+        });
       } else if (message.type === 'columnStats' && message.cacheId === cacheId) {
         if (message.data) {
-          setColumnStatsMap(prev => ({
-            ...prev,
-            [message.data.column]: message.data
-          }));
+          setColumnStatsMap((prev) => ({ ...prev, [message.data.column]: message.data }));
         }
         setStatsError(message.error || null);
         setLoadingStatsColumn(null);
       } else if (message.type === 'columnSummaries' && message.cacheId === cacheId) {
-        if (message.data) {
-          setColumnSummaries(message.data);
-        }
+        if (message.data) setColumnSummaries(message.data);
         setLoadingSummaries(false);
         setSummariesLoaded(true);
       } else if (message.type === 'distinctValues' && message.cacheId === cacheId) {
@@ -193,8 +377,13 @@ export function ResultsTable({
         setColumnCardinality(message.cardinality || 0);
         setLoadingDistinct(false);
       } else if (message.type === 'filterError' && message.cacheId === cacheId) {
+        if (
+          typeof message.requestVersion === 'number' &&
+          message.requestVersion !== cacheVersion.current
+        ) {
+          return;
+        }
         toast.show(message.error || 'Filter error');
-        setIsLoadingPage(false);
       } else if (message.type === 'copyData') {
         setCopyLoading(false);
         if (message.error) {
@@ -204,8 +393,8 @@ export function ResultsTable({
           const text = formatTableAsText(copyColumns, copyRows);
           navigator.clipboard.writeText(text).then(() => {
             const rowCount = copyRows.length;
-            const label = rowCount >= limit 
-              ? `${rowCount.toLocaleString()} rows (limit)` 
+            const label = rowCount >= limit
+              ? `${rowCount.toLocaleString()} rows (limit)`
               : `${rowCount.toLocaleString()} rows`;
             toast.show(`Copied ${label}`);
           }).catch(() => {
@@ -219,76 +408,55 @@ export function ResultsTable({
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [cacheId]);
+  }, [cacheId, pageSize, renderStart, renderEnd, toast]);
 
-  // Compute active where clause
-  const getActiveWhereClause = useCallback((): string => {
-    if (filterState.isPaused) return '';
-    return filtersToWhereClause(filterState.filters);
-  }, [filterState]);
+  // --------------------------------------------------------------------------
+  // Sort / filter handlers — all converge on resetAndReload.
+  // --------------------------------------------------------------------------
+  const handleSort = useCallback((column: string) => {
+    let next: { column: string | null; direction: SortDirection };
+    if (sort.column !== column) next = { column, direction: 'asc' };
+    else if (sort.direction === 'asc') next = { column, direction: 'desc' };
+    else next = { column: null, direction: null };
+    setSort(next);
+    resetAndReload(next.column, next.direction, getActiveWhereClause());
+  }, [sort, resetAndReload, getActiveWhereClause]);
 
-  // Request a page from the server
-  const requestPage = useCallback((offset: number, sortColumn?: string | null, sortDirection?: SortDirection, whereClause?: string) => {
-    if (!cacheId) return;
-    
-    setIsLoadingPage(true);
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ 
-        type: 'requestPage', 
-        cacheId, 
-        offset,
-        sortColumn: sortColumn || undefined,
-        sortDirection: sortDirection || undefined,
-        whereClause: whereClause ?? getActiveWhereClause(),
-      });
-    }
-  }, [cacheId, getActiveWhereClause]);
-
-  // Handle page navigation
-  const goToPage = useCallback((pageNum: number) => {
-    const newOffset = (pageNum - 1) * pageSize;
-    requestPage(newOffset, sort.column, sort.direction);
-  }, [pageSize, requestPage, sort]);
-
-  // Filter handlers
   const applyFilters = useCallback((newFilters: ColumnFilter[]) => {
     const clause = filtersToWhereClause(newFilters);
-    requestPage(0, sort.column, sort.direction, clause);
-  }, [requestPage, sort]);
+    resetAndReload(sort.column, sort.direction, clause);
+  }, [resetAndReload, sort]);
 
   const handleAddFilter = useCallback((filter: ColumnFilter) => {
     const newFilters = [...filterState.filters, filter];
-    setFilterState(prev => ({ ...prev, filters: newFilters }));
+    setFilterState((prev) => ({ ...prev, filters: newFilters }));
     applyFilters(newFilters);
     setFilterPopover(null);
   }, [filterState.filters, applyFilters]);
 
   const handleRemoveFilter = useCallback((filterId: string) => {
-    const newFilters = filterState.filters.filter(f => f.id !== filterId);
-    setFilterState(prev => ({ ...prev, filters: newFilters }));
+    const newFilters = filterState.filters.filter((f) => f.id !== filterId);
+    setFilterState((prev) => ({ ...prev, filters: newFilters }));
     applyFilters(newFilters);
   }, [filterState.filters, applyFilters]);
 
   const handleClearFilters = useCallback(() => {
     setFilterState(createInitialFilterState());
-    requestPage(0, sort.column, sort.direction, '');
-  }, [requestPage, sort]);
+    resetAndReload(sort.column, sort.direction, '');
+  }, [resetAndReload, sort]);
 
   const handleTogglePause = useCallback(() => {
-    setFilterState(prev => {
+    setFilterState((prev) => {
       const newPaused = !prev.isPaused;
-      // Re-fetch with or without filters using latest state
       const clause = newPaused ? '' : filtersToWhereClause(prev.filters);
-      requestPage(0, sort.column, sort.direction, clause);
+      resetAndReload(sort.column, sort.direction, clause);
       return { ...prev, isPaused: newPaused };
     });
-  }, [requestPage, sort]);
+  }, [resetAndReload, sort]);
 
   const handleOpenFilterPopover = useCallback((column: string, columnType: string, event: React.MouseEvent) => {
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
     const tableRect = tableWrapperRef.current?.getBoundingClientRect();
-    
     setFilterPopover({
       column,
       columnType,
@@ -297,68 +465,45 @@ export function ResultsTable({
         left: rect.left - (tableRect?.left || 0),
       },
     });
-    
-    // Request distinct values
     setLoadingDistinct(true);
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ type: 'requestDistinctValues', cacheId, column });
-    }
+    getVscodeApi()?.postMessage({ type: 'requestDistinctValues', cacheId, column });
   }, [cacheId]);
 
-  // Handle export/open request
+  // --------------------------------------------------------------------------
+  // Export, copy, refresh, navigation
+  // --------------------------------------------------------------------------
   const handleExport = useCallback((format: 'csv' | 'parquet' | 'json' | 'jsonl' | 'csv-tab' | 'json-tab') => {
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ type: 'export', cacheId, format });
-    }
+    getVscodeApi()?.postMessage({ type: 'export', cacheId, format });
   }, [cacheId]);
 
-  // Request column summaries from extension (uses SUMMARIZE)
   const requestColumnSummaries = useCallback(() => {
     if (!cacheId || summariesLoaded) return;
-    
     setLoadingSummaries(true);
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ type: 'requestColumnSummaries', cacheId });
-    } else {
-      setLoadingSummaries(false);
-    }
+    getVscodeApi()?.postMessage({ type: 'requestColumnSummaries', cacheId });
   }, [cacheId, summariesLoaded]);
 
-  // Get the active where clause for filtered stats
   const activeWhereClause = useMemo(() => {
     if (filterState.isPaused || filterState.filters.length === 0) return undefined;
     return filtersToWhereClause(filterState.filters);
   }, [filterState]);
 
-  // Clear column stats cache when filters change (stats need to be re-computed with new filter)
+  // Clear column stats when filters change (stats need re-computation).
   useEffect(() => {
     setColumnStatsMap({});
   }, [activeWhereClause]);
 
-  // Request column stats from extension
   const requestColumnStats = useCallback((columnName: string) => {
     if (!cacheId) return;
-    
     setLoadingStatsColumn(columnName);
     setStatsError(null);
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ 
-        type: 'requestColumnStats', 
-        cacheId, 
-        column: columnName,
-        whereClause: activeWhereClause,
-      });
-    } else {
-      setLoadingStatsColumn(null);
-      setStatsError('VS Code API not available');
-    }
+    getVscodeApi()?.postMessage({
+      type: 'requestColumnStats',
+      cacheId,
+      column: columnName,
+      whereClause: activeWhereClause,
+    });
   }, [cacheId, activeWhereClause]);
 
-  // Toggle columns panel for a specific column
   const openColumnStats = useCallback((columnName: string) => {
     if (showColumnsPanel && initialExpandedColumn === columnName) {
       setShowColumnsPanel(false);
@@ -366,37 +511,15 @@ export function ResultsTable({
     } else {
       setInitialExpandedColumn(columnName);
       setShowColumnsPanel(true);
-      // Request summaries if not loaded yet
-      if (!summariesLoaded) {
-        requestColumnSummaries();
-      }
+      if (!summariesLoaded) requestColumnSummaries();
       requestColumnStats(columnName);
     }
   }, [showColumnsPanel, initialExpandedColumn, requestColumnStats, summariesLoaded, requestColumnSummaries]);
 
-  // Handle column header click for sorting (server-side)
-  const handleSort = useCallback((column: string) => {
-    let newSort: { column: string | null; direction: SortDirection };
-    
-    if (sort.column !== column) {
-      newSort = { column, direction: 'asc' };
-    } else if (sort.direction === 'asc') {
-      newSort = { column, direction: 'desc' };
-    } else {
-      newSort = { column: null, direction: null };
-    }
-    
-    setSort(newSort);
-    // Request first page with new sort
-    requestPage(0, newSort.column, newSort.direction);
-  }, [sort, requestPage]);
-
-  // Handle column resize
   const handleColumnResize = useCallback((column: string, width: number) => {
-    setColumnWidths(prev => ({ ...prev, [column]: Math.max(50, width) }));
+    setColumnWidths((prev) => ({ ...prev, [column]: Math.max(50, width) }));
   }, []);
 
-  // Copy to clipboard (for current page selection)
   const copyToClipboard = useCallback(async (text: string, label: string) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -406,39 +529,38 @@ export function ResultsTable({
     }
   }, [toast]);
 
-  // Copy full table from server (up to maxCopyRows)
   const copyFullTable = useCallback(() => {
     if (!cacheId || copyLoading) return;
     setCopyLoading(true);
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ type: 'requestCopyData', cacheId });
-    } else {
-      setCopyLoading(false);
-    }
+    getVscodeApi()?.postMessage({ type: 'requestCopyData', cacheId });
   }, [cacheId, copyLoading]);
 
-  // Handle refresh - re-execute original query
   const handleRefresh = useCallback(() => {
     if (isRefreshing) return;
     setIsRefreshing(true);
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ type: 'refreshQuery' });
-    } else {
-      setIsRefreshing(false);
-    }
+    getVscodeApi()?.postMessage({ type: 'refreshQuery' });
   }, [isRefreshing]);
 
-  // Handle go to source - open the source file in the editor
   const handleGoToSource = useCallback(() => {
-    const vscode = getVscodeApi();
-    if (vscode) {
-      vscode.postMessage({ type: 'goToSource' });
-    }
+    getVscodeApi()?.postMessage({ type: 'goToSource' });
   }, []);
 
-  // Selection helpers (work on current page)
+  const handleRunAdHoc = useCallback((nextSql: string) => {
+    setIsRefreshing(true);
+    getVscodeApi()?.postMessage({ type: 'runAdHoc', sql: nextSql });
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Selection helpers — operate on absolute row indexes.
+  // Lookups against `chunks` resolve only the rows that are currently cached;
+  // un-cached rows in a selected range produce '—' on copy.
+  // --------------------------------------------------------------------------
+  const lookupRow = useCallback((rowIdx: number): Record<string, unknown> | null => {
+    const chunkIdx = Math.floor(rowIdx / pageSize);
+    const chunk = chunks.get(chunkIdx);
+    return chunk ? chunk[rowIdx % pageSize] ?? null : null;
+  }, [chunks, pageSize]);
+
   const isCellSelected = useCallback((rowIdx: number, colIdx: number): boolean => {
     if (!selection) return false;
     const minRow = Math.min(selection.start.row, selection.end.row);
@@ -463,77 +585,98 @@ export function ResultsTable({
     const maxRow = Math.max(selection.start.row, selection.end.row);
     const minCol = Math.min(selection.start.col, selection.end.col);
     const maxCol = Math.max(selection.start.col, selection.end.col);
-    return colIdx >= minCol && colIdx <= maxCol && minRow === 0 && maxRow === displayRows.length - 1;
-  }, [selection, displayRows.length]);
+    return colIdx >= minCol && colIdx <= maxCol && minRow === 0 && maxRow === filteredRowCount - 1;
+  }, [selection, filteredRowCount]);
 
-  // Handle cell click
   const handleCellClick = useCallback((rowIdx: number, colIdx: number, e: React.MouseEvent) => {
     if (e.shiftKey && selection) {
-      setSelection(prev => prev ? { start: prev.start, end: { row: rowIdx, col: colIdx } } : null);
+      setSelection((prev) => prev ? { start: prev.start, end: { row: rowIdx, col: colIdx } } : null);
     } else {
-      const isSingleCellSelected = selection && 
-        selection.start.row === selection.end.row && 
+      const single = selection &&
+        selection.start.row === selection.end.row &&
         selection.start.col === selection.end.col &&
-        selection.start.row === rowIdx && 
+        selection.start.row === rowIdx &&
         selection.start.col === colIdx;
-      if (isSingleCellSelected) {
-        setSelection(null);
-      } else {
-        setSelection({ start: { row: rowIdx, col: colIdx }, end: { row: rowIdx, col: colIdx } });
-      }
+      setSelection(single ? null : { start: { row: rowIdx, col: colIdx }, end: { row: rowIdx, col: colIdx } });
     }
   }, [selection]);
 
-  // Handle cell double-click
   const handleCellDoubleClick = useCallback((rowIdx: number, colIdx: number) => {
-    const row = displayRows[rowIdx];
+    const row = lookupRow(rowIdx);
+    if (!row) return;
     const col = columns[colIdx];
     setExpandedCell({ value: row[col], column: col });
-  }, [displayRows, columns]);
+  }, [lookupRow, columns]);
 
-  // Handle row select
   const handleRowSelect = useCallback((rowIdx: number, e: React.MouseEvent) => {
     if (e.shiftKey && selection) {
-      setSelection(prev => prev ? { start: { row: prev.start.row, col: 0 }, end: { row: rowIdx, col: columns.length - 1 } } : null);
+      setSelection((prev) => prev ? { start: { row: prev.start.row, col: 0 }, end: { row: rowIdx, col: columns.length - 1 } } : null);
     } else {
       setSelection({ start: { row: rowIdx, col: 0 }, end: { row: rowIdx, col: columns.length - 1 } });
     }
   }, [selection, columns.length]);
 
-  // Handle column select
   const handleColumnSelect = useCallback((colIdx: number, e: React.MouseEvent) => {
     if (e.shiftKey && selection) {
-      setSelection(prev => prev ? { start: { row: 0, col: prev.start.col }, end: { row: displayRows.length - 1, col: colIdx } } : null);
+      setSelection((prev) => prev ? { start: { row: 0, col: prev.start.col }, end: { row: filteredRowCount - 1, col: colIdx } } : null);
     } else {
-      setSelection({ start: { row: 0, col: colIdx }, end: { row: displayRows.length - 1, col: colIdx } });
+      setSelection({ start: { row: 0, col: colIdx }, end: { row: filteredRowCount - 1, col: colIdx } });
     }
-  }, [selection, displayRows.length]);
+  }, [selection, filteredRowCount]);
 
-  // Select all (current page)
   const selectAll = useCallback(() => {
-    if (displayRows.length === 0) return;
-    setSelection({ start: { row: 0, col: 0 }, end: { row: displayRows.length - 1, col: columns.length - 1 } });
-  }, [displayRows.length, columns.length]);
+    if (filteredRowCount === 0) return;
+    setSelection({ start: { row: 0, col: 0 }, end: { row: filteredRowCount - 1, col: columns.length - 1 } });
+  }, [filteredRowCount, columns.length]);
 
-  // Get selection as text (current page only)
   const getSelectionText = useCallback((): string => {
-    if (!selection) return formatTableAsText(columns, displayRows);
+    /**
+     * Cap selection-text materialization. With virtualized scroll, a
+     * column-select on a 10M-row table would otherwise build a 10M-line
+     * string (and most rows aren't cached anyway). The "Copy Table"
+     * button is the right tool for full-result exports.
+     */
+    const SELECTION_ROW_CAP = 10_000;
+
+    if (!selection) {
+      // No explicit selection: copy the currently-rendered slice.
+      const rendered: Record<string, unknown>[] = [];
+      for (let r = renderStart; r < renderEnd; r++) {
+        const row = lookupRow(r);
+        if (row) rendered.push(row);
+      }
+      return formatTableAsText(columns, rendered);
+    }
     const minRow = Math.min(selection.start.row, selection.end.row);
     const maxRow = Math.max(selection.start.row, selection.end.row);
     const minCol = Math.min(selection.start.col, selection.end.col);
     const maxCol = Math.max(selection.start.col, selection.end.col);
     const selectedCols = columns.slice(minCol, maxCol + 1);
-    const selectedRows = displayRows.slice(minRow, maxRow + 1);
     if (minRow === maxRow && minCol === maxCol) {
-      const row = displayRows[minRow];
-      return formatValue(row[columns[minCol]]);
+      const row = lookupRow(minRow);
+      return row ? formatValue(row[columns[minCol]]) : '';
     }
-    return selectedRows.map(row => selectedCols.map(col => formatValue(row[col])).join('\t')).join('\n');
-  }, [selection, columns, displayRows]);
+    const effectiveMax = Math.min(maxRow, minRow + SELECTION_ROW_CAP - 1);
+    const truncated = maxRow > effectiveMax;
+    const lines: string[] = [];
+    for (let r = minRow; r <= effectiveMax; r++) {
+      const row = lookupRow(r);
+      if (!row) {
+        // Row not cached yet — placeholder so column alignment is preserved.
+        lines.push(selectedCols.map(() => '').join('\t'));
+      } else {
+        lines.push(selectedCols.map((col) => formatValue(row[col])).join('\t'));
+      }
+    }
+    if (truncated) {
+      // Mention this in-line so the user knows why the copy is shorter.
+      lines.push(`-- truncated at ${SELECTION_ROW_CAP.toLocaleString()} rows; use "Copy Table" for the full export`);
+    }
+    return lines.join('\n');
+  }, [selection, columns, lookupRow, renderStart, renderEnd]);
 
-  // Get selection label
   const getSelectionLabel = useCallback((): string => {
-    if (!selection) return 'page';
+    if (!selection) return 'visible rows';
     const minRow = Math.min(selection.start.row, selection.end.row);
     const maxRow = Math.max(selection.start.row, selection.end.row);
     const minCol = Math.min(selection.start.col, selection.end.col);
@@ -559,15 +702,12 @@ export function ResultsTable({
         e.preventDefault();
         selectAll();
       }
-      if (e.key === 'Escape') {
-        setSelection(null);
-      }
+      if (e.key === 'Escape') setSelection(null);
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [getSelectionText, getSelectionLabel, copyToClipboard, selectAll]);
 
-  // Selection info
   const selectionInfo = useMemo(() => {
     if (!selection) return null;
     const minRow = Math.min(selection.start.row, selection.end.row);
@@ -580,43 +720,39 @@ export function ResultsTable({
     return `${rowCount}×${colCount}`;
   }, [selection]);
 
-  // Build full SQL with original query, filters, and sort
+  // Build full SQL with original query + filters + sort
   const fullSql = useMemo(() => {
     const whereClause = filtersToWhereClause(filterState.filters);
     const hasFilters = whereClause.length > 0 && !filterState.isPaused;
     const hasSort = sort.column !== null;
-    
-    // If no modifications, just return the original SQL
-    if (!hasFilters && !hasSort) {
-      return sql;
-    }
-    
-    // Wrap original query and add modifications
+    if (!hasFilters && !hasSort) return sql;
     const parts: string[] = [];
     parts.push('SELECT * FROM (');
     parts.push('  ' + sql.trim().replace(/;?\s*$/, '').split('\n').join('\n  '));
     parts.push(') AS _query');
-    
-    if (hasFilters) {
-      parts.push(`WHERE ${whereClause}`);
-    }
-    
-    if (hasSort) {
-      parts.push(`ORDER BY "${sort.column}" ${sort.direction?.toUpperCase() || 'ASC'}`);
-    }
-    
+    if (hasFilters) parts.push(`WHERE ${whereClause}`);
+    if (hasSort) parts.push(`ORDER BY "${sort.column}" ${sort.direction?.toUpperCase() || 'ASC'}`);
     return parts.join('\n');
   }, [sql, filterState, sort]);
 
-  // Statement label for multi-statement
-  const statementLabel = totalStatements !== undefined && statementIndex !== undefined 
+  const statementLabel = totalStatements !== undefined && statementIndex !== undefined
     ? `Query ${statementIndex + 1} of ${totalStatements}`
     : null;
 
-  // Row number offset for display
-  const rowNumberOffset = currentOffset;
+  // --------------------------------------------------------------------------
+  // Build the visible row list (for rendering).
+  // --------------------------------------------------------------------------
+  const visibleRows = useMemo(() => {
+    const out: { index: number; row: Record<string, unknown> | null }[] = [];
+    for (let i = renderStart; i < renderEnd; i++) {
+      out.push({ index: i, row: lookupRow(i) });
+    }
+    return out;
+  }, [renderStart, renderEnd, lookupRow]);
 
-  // Collapsed view - same header structure, just clickable to expand
+  // --------------------------------------------------------------------------
+  // Collapsed view (collapsible mode)
+  // --------------------------------------------------------------------------
   if (isCollapsible && !isExpanded) {
     return (
       <div className="results-container collapsed" onClick={onToggleExpand}>
@@ -641,17 +777,8 @@ export function ResultsTable({
 
   return (
     <div className={`results-container ${isCollapsible ? 'collapsible' : ''} ${!hasResults ? 'no-results' : ''}`}>
-      {/* Toast Notification */}
       <Toast message={toast.message} />
-      
-      {/* Loading overlay */}
-      {isLoadingPage && (
-        <div className="loading-overlay">
-          <span>Loading...</span>
-        </div>
-      )}
-      
-      {/* Cell Expansion Modal */}
+
       {expandedCell && (
         <CellExpansionModal
           value={expandedCell.value}
@@ -661,7 +788,6 @@ export function ResultsTable({
         />
       )}
 
-      {/* Columns Panel */}
       {showColumnsPanel && (
         <ColumnsPanel
           columns={columns}
@@ -678,44 +804,33 @@ export function ResultsTable({
         />
       )}
 
-      {/* SQL Modal (original query) */}
       {showSqlModal && (
         <SqlModal
           sql={sql}
           onClose={() => setShowSqlModal(false)}
           onCopy={(text) => copyToClipboard(text, 'SQL')}
           onGoToSource={handleGoToSource}
+          onRun={handleRunAdHoc}
         />
       )}
 
-      {/* Full SQL Modal (with filters and sort) */}
       {showFullSqlModal && (
         <SqlModal
           sql={fullSql}
           onClose={() => setShowFullSqlModal(false)}
           onCopy={(text) => copyToClipboard(text, 'SQL')}
+          onRun={handleRunAdHoc}
           title="View Query"
         />
       )}
 
-      {/* Query Header - consistent with collapsed state */}
+      {/* Query header */}
       <div className="query-header">
-        {/* Collapse toggle for collapsible mode */}
         {isCollapsible && (
-          <span 
-            className="query-expand-icon" 
-            onClick={onToggleExpand}
-            title="Collapse"
-          >
-            ▼
-          </span>
+          <span className="query-expand-icon" onClick={onToggleExpand} title="Collapse">▼</span>
         )}
         {statementLabel && <span className="query-label">{statementLabel}</span>}
-        <code 
-          className="query-sql"
-          onClick={() => setShowSqlModal(true)}
-          title="Click to view full SQL"
-        >
+        <code className="query-sql" onClick={() => setShowSqlModal(true)} title="Click to view full SQL">
           <SqlPreview sql={sql} />
         </code>
         <span className="query-meta">
@@ -736,27 +851,24 @@ export function ResultsTable({
         </span>
       </div>
 
-      {/* Stats Bar - rows, cols, sort, page, selection (only show when there are results) */}
+      {/* Stats bar */}
       {hasResults && (
         <div className="stats-bar">
           <div className="stat">
             <span className="stat-label">rows</span>
             <span className="stat-value">
-              {filteredRowCount < totalRows 
+              {filteredRowCount < totalRows
                 ? <>{filteredRowCount.toLocaleString()} <span className="stat-total">/ {totalRows.toLocaleString()}</span></>
                 : totalRows.toLocaleString()
               }
             </span>
           </div>
-          <button 
+          <button
             className={`stat stat-clickable ${showColumnsPanel ? 'active' : ''}`}
             onClick={() => {
               const newShow = !showColumnsPanel;
               setShowColumnsPanel(newShow);
-              // Request summaries when opening if not already loaded
-              if (newShow && !summariesLoaded) {
-                requestColumnSummaries();
-              }
+              if (newShow && !summariesLoaded) requestColumnSummaries();
             }}
             title="Toggle columns panel"
           >
@@ -767,12 +879,6 @@ export function ResultsTable({
             <div className="stat">
               <span className="stat-label">sort</span>
               <span className="stat-value">{sort.column} {sort.direction === 'asc' ? '↑' : '↓'}</span>
-            </div>
-          )}
-          {totalPages > 1 && (
-            <div className="stat">
-              <span className="stat-label">page</span>
-              <span className="stat-value">{currentPageNum} / {totalPages}</span>
             </div>
           )}
           {selectionInfo && (
@@ -794,7 +900,7 @@ export function ResultsTable({
         </div>
       )}
 
-      {/* Filter Bar */}
+      {/* Filter bar */}
       {hasResults && totalRows > 0 && (
         <FilterBar
           filterState={filterState}
@@ -802,7 +908,6 @@ export function ResultsTable({
           onClearAll={handleClearFilters}
           onTogglePause={handleTogglePause}
           onAddFilter={() => {
-            // Show filter popover for first column as fallback
             if (columns.length > 0 && tableWrapperRef.current) {
               const firstHeader = tableWrapperRef.current.querySelector('th:not(.row-number-header)');
               if (firstHeader) {
@@ -814,25 +919,20 @@ export function ResultsTable({
                   position: { top: rect.bottom - tableRect.top + 4, left: rect.left - tableRect.left },
                 });
                 setLoadingDistinct(true);
-                const vscode = getVscodeApi();
-                if (vscode) {
-                  vscode.postMessage({ type: 'requestDistinctValues', cacheId, column: columns[0] });
-                }
+                getVscodeApi()?.postMessage({ type: 'requestDistinctValues', cacheId, column: columns[0] });
               }
             }
           }}
         />
       )}
 
-      {/* Results Table or Empty State */}
+      {/* Results table or empty state */}
       {!hasResults ? (
-        // DDL/DML - no table structure
         <div className="empty-state">
           <span className="empty-icon">✓</span>
           <span>Statement executed successfully</span>
         </div>
-      ) : totalRows === 0 ? (
-        // SELECT with 0 rows - show column headers
+      ) : filteredRowCount === 0 ? (
         <div className="empty-results">
           <div className="table-wrapper">
             <table>
@@ -851,7 +951,7 @@ export function ResultsTable({
               <tbody>
                 <tr>
                   <td colSpan={columns.length + 1} className="empty-row-message">
-                    0 rows returned
+                    {totalRows === 0 ? '0 rows returned' : '0 rows match the current filters'}
                   </td>
                 </tr>
               </tbody>
@@ -860,7 +960,6 @@ export function ResultsTable({
         </div>
       ) : (
         <div className="table-wrapper" ref={tableWrapperRef} tabIndex={0}>
-          {/* Column Filter Popover */}
           {filterPopover && (
             <ColumnFilterPopover
               column={filterPopover.column}
@@ -872,25 +971,22 @@ export function ResultsTable({
               onClose={() => setFilterPopover(null)}
               onApply={handleAddFilter}
               onColumnChange={(newCol, newType) => {
-                setFilterPopover(prev => prev ? { ...prev, column: newCol, columnType: newType } : null);
+                setFilterPopover((prev) => prev ? { ...prev, column: newCol, columnType: newType } : null);
                 setDistinctValues([]);
                 setColumnCardinality(0);
                 setLoadingDistinct(true);
-                const vscode = getVscodeApi();
-                if (vscode) {
-                  vscode.postMessage({ type: 'requestDistinctValues', cacheId, column: newCol });
-                }
+                getVscodeApi()?.postMessage({ type: 'requestDistinctValues', cacheId, column: newCol });
               }}
               position={filterPopover.position}
             />
           )}
-          
+
           <table>
             <thead>
-              <tr>
+              <tr ref={headerRowRef}>
                 <th className="row-number-header">#</th>
                 {columns.map((col, idx) => {
-                  const hasFilter = filterState.filters.some(f => f.column === col);
+                  const hasFilter = filterState.filters.some((f) => f.column === col);
                   return (
                     <ResizableHeader
                       key={idx}
@@ -911,102 +1007,94 @@ export function ResultsTable({
               </tr>
             </thead>
             <tbody>
-              {displayRows.map((row, rowIdx) => (
-                <tr key={rowIdx} className={isRowSelected(rowIdx) ? 'row-selected' : ''}>
-                  <td className="row-number" onClick={(e) => handleRowSelect(rowIdx, e)}>
-                    {rowNumberOffset + rowIdx + 1}
-                  </td>
-                  {columns.map((col, colIdx) => (
-                    <td 
-                      key={colIdx}
-                      className={isCellSelected(rowIdx, colIdx) ? 'selected' : ''}
-                      style={columnWidths[col] ? { width: columnWidths[col], minWidth: columnWidths[col], maxWidth: columnWidths[col] } : undefined}
-                      onClick={(e) => handleCellClick(rowIdx, colIdx, e)}
-                      onDoubleClick={() => handleCellDoubleClick(rowIdx, colIdx)}
-                    >
-                      <CellValue value={row[col]} />
-                    </td>
-                  ))}
+              {topSpacerHeight > 0 && (
+                <tr aria-hidden className="virt-spacer">
+                  <td colSpan={columns.length + 1} style={{ height: topSpacerHeight }} />
                 </tr>
-              ))}
+              )}
+              {visibleRows.map(({ index, row }, sliceIdx) => {
+                const isFirst = sliceIdx === 0;
+                const rowSel = isRowSelected(index);
+                if (!row) {
+                  return (
+                    <tr
+                      key={index}
+                      ref={isFirst ? firstRenderedRowRef : null}
+                      className="virt-row virt-row-loading"
+                    >
+                      <td className="row-number">{index + 1}</td>
+                      {columns.map((col, colIdx) => (
+                        <td key={colIdx} className="cell-loading">
+                          <span className="cell-skeleton" />
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                }
+                return (
+                  <tr
+                    key={index}
+                    ref={isFirst ? firstRenderedRowRef : null}
+                    className={`virt-row ${rowSel ? 'row-selected' : ''}`}
+                  >
+                    <td className="row-number" onClick={(e) => handleRowSelect(index, e)}>
+                      {index + 1}
+                    </td>
+                    {columns.map((col, colIdx) => (
+                      <td
+                        key={colIdx}
+                        className={isCellSelected(index, colIdx) ? 'selected' : ''}
+                        style={columnWidths[col] ? { width: columnWidths[col], minWidth: columnWidths[col], maxWidth: columnWidths[col] } : undefined}
+                        onClick={(e) => handleCellClick(index, colIdx, e)}
+                        onDoubleClick={() => handleCellDoubleClick(index, colIdx)}
+                      >
+                        <CellValue value={row[col]} />
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+              {bottomSpacerHeight > 0 && (
+                <tr aria-hidden className="virt-spacer">
+                  <td colSpan={columns.length + 1} style={{ height: bottomSpacerHeight }} />
+                </tr>
+              )}
             </tbody>
           </table>
         </div>
       )}
 
-      {/* Fixed Footer with Pagination and Actions (only show when there are results) */}
-      {hasResults && (
+      {/* Footer (no pagination — infinite virtualized scroll) */}
+      {hasResults && filteredRowCount > 0 && (
         <div className="results-footer">
-          {/* Pagination controls */}
-          {totalPages > 1 && (
-            <div className="pagination">
-              <button 
-                className="btn btn-surface pagination-btn"
-                onClick={() => goToPage(1)}
-                disabled={currentPageNum === 1 || isLoadingPage}
-                title="First page"
-              >
-                ⟨⟨
-              </button>
-              <button 
-                className="btn btn-surface pagination-btn"
-                onClick={() => goToPage(currentPageNum - 1)}
-                disabled={currentPageNum === 1 || isLoadingPage}
-                title="Previous page"
-              >
-                ⟨
-              </button>
-              <span className="pagination-info">
-                {currentPageNum} / {totalPages}
-              </span>
-              <button 
-                className="btn btn-surface pagination-btn"
-                onClick={() => goToPage(currentPageNum + 1)}
-                disabled={currentPageNum === totalPages || isLoadingPage}
-                title="Next page"
-              >
-                ⟩
-              </button>
-              <button 
-                className="btn btn-surface pagination-btn"
-                onClick={() => goToPage(totalPages)}
-                disabled={currentPageNum === totalPages || isLoadingPage}
-                title="Last page"
-              >
-                ⟩⟩
-              </button>
-            </div>
-          )}
-          
-          {/* Actions */}
           <div className="footer-actions">
-          <IconButton
-            icon={<Copy size={14} />}
-            tooltip={`Copy table (up to ${maxCopyRows.toLocaleString()} rows)`}
-            onClick={copyFullTable}
-            disabled={copyLoading}
-            tooltipPosition="top"
-          />
-          <PopoverMenu trigger={
-            <IconButton icon={<Download size={14} />} tooltip="Export to file">
-              <ChevronDown size={12} />
-            </IconButton>
-          }>
-            <button onClick={() => handleExport('csv')}>CSV</button>
-            <button onClick={() => handleExport('parquet')}>Parquet</button>
-            <button onClick={() => handleExport('json')}>JSON</button>
-            <button onClick={() => handleExport('jsonl')}>JSONL</button>
-          </PopoverMenu>
-          <PopoverMenu trigger={
-            <IconButton icon={<ExternalLink size={14} />} tooltip={`Open in new tab (up to ${maxCopyRows.toLocaleString()} rows)`}>
-              <ChevronDown size={12} />
-            </IconButton>
-          }>
-            <button onClick={() => handleExport('csv-tab')}>CSV</button>
-            <button onClick={() => handleExport('json-tab')}>JSON</button>
-          </PopoverMenu>
+            <IconButton
+              icon={<Copy size={14} />}
+              tooltip={`Copy table (up to ${maxCopyRows.toLocaleString()} rows)`}
+              onClick={copyFullTable}
+              disabled={copyLoading}
+              tooltipPosition="top"
+            />
+            <PopoverMenu trigger={
+              <IconButton icon={<Download size={14} />} tooltip="Export to file">
+                <ChevronDown size={12} />
+              </IconButton>
+            }>
+              <button onClick={() => handleExport('csv')}>CSV</button>
+              <button onClick={() => handleExport('parquet')}>Parquet</button>
+              <button onClick={() => handleExport('json')}>JSON</button>
+              <button onClick={() => handleExport('jsonl')}>JSONL</button>
+            </PopoverMenu>
+            <PopoverMenu trigger={
+              <IconButton icon={<ExternalLink size={14} />} tooltip={`Open in new tab (up to ${maxCopyRows.toLocaleString()} rows)`}>
+                <ChevronDown size={12} />
+              </IconButton>
+            }>
+              <button onClick={() => handleExport('csv-tab')}>CSV</button>
+              <button onClick={() => handleExport('json-tab')}>JSON</button>
+            </PopoverMenu>
+          </div>
         </div>
-      </div>
       )}
     </div>
   );
@@ -1068,9 +1156,9 @@ function ResizableHeader({ column, width, isSorted, sortDirection, isSelected, h
         <div className="th-actions">
           <CopyButton text={column} title={`Copy "${column}"`} className="th-copy-btn" size={12} />
           {onOpenFilter && (
-            <button 
-              className={`header-icon-btn filter-btn ${hasFilter ? 'active' : ''}`} 
-              onClick={(e) => { e.stopPropagation(); onOpenFilter(e); }} 
+            <button
+              className={`header-icon-btn filter-btn ${hasFilter ? 'active' : ''}`}
+              onClick={(e) => { e.stopPropagation(); onOpenFilter(e); }}
               title={`Filter by ${column}`}
             >
               <Filter size={12} />
@@ -1099,7 +1187,7 @@ interface CellExpansionModalProps {
 
 function CellExpansionModal({ value, column, onClose, onCopy }: CellExpansionModalProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  
+
   const displayText = useMemo(() => {
     if (value === null || value === undefined) return 'NULL';
     if (typeof value === 'object') {
@@ -1140,5 +1228,3 @@ function CellExpansionModal({ value, column, onClose, onCopy }: CellExpansionMod
     </Modal>
   );
 }
-
-

--- a/src/webview/index.tsx
+++ b/src/webview/index.tsx
@@ -52,9 +52,12 @@ function App() {
           maxCopyRows: message.maxCopyRows || prev.maxCopyRows,
         }));
       } else if (message.type === 'fileMetadata') {
+        // `silent: true` means the host pre-loaded metadata while jumping
+        // straight into the data view — we record it (so "Back to Overview"
+        // works) but don't change the visible view.
         setState(prev => ({
           ...prev,
-          viewMode: 'fileOverview',
+          viewMode: message.silent ? prev.viewMode : 'fileOverview',
           fileMetadata: message.data,
           pageSize: message.pageSize || prev.pageSize,
           maxCopyRows: message.maxCopyRows || prev.maxCopyRows,
@@ -90,10 +93,19 @@ function App() {
 
   if (state.viewMode === 'loading') {
     const isError = state.loadingMessage.startsWith('Error:');
+    const canFallBackToSchema = isError && state.fileMetadata !== null;
     return (
       <div className="loading">
         {!isError && <div className="loading-spinner" />}
         <span className={isError ? 'loading-error' : 'loading-text'}>{state.loadingMessage}</span>
+        {canFallBackToSchema && (
+          <button
+            className="btn btn-surface"
+            onClick={() => setState(prev => ({ ...prev, viewMode: 'fileOverview' }))}
+          >
+            Back to Schema
+          </button>
+        )}
       </div>
     );
   }

--- a/src/webview/index.tsx
+++ b/src/webview/index.tsx
@@ -27,6 +27,8 @@ interface AppState {
   containerMetadata: ContainerOverviewMetadata | null;
   pageSize: number;
   maxCopyRows: number;
+  /** True when the current cache reflects the full source and write-back is supported. */
+  editable: boolean;
 }
 
 function App() {
@@ -38,6 +40,7 @@ function App() {
     containerMetadata: null,
     pageSize: 1000,
     maxCopyRows: 50000,
+    editable: false,
   });
 
   React.useEffect(() => {
@@ -50,6 +53,7 @@ function App() {
           result: message.data,
           pageSize: message.pageSize || prev.pageSize,
           maxCopyRows: message.maxCopyRows || prev.maxCopyRows,
+          editable: message.editable === true,
         }));
       } else if (message.type === 'fileMetadata') {
         // `silent: true` means the host pre-loaded metadata while jumping
@@ -130,10 +134,11 @@ function App() {
   if (state.viewMode === 'results' && state.result) {
     const showBackButton = state.fileMetadata !== null;
     return (
-      <QueryPanel 
-        result={state.result} 
+      <QueryPanel
+        result={state.result}
         pageSize={state.pageSize}
         maxCopyRows={state.maxCopyRows}
+        editable={state.editable}
         onBackToOverview={showBackButton ? () => {
           setState(prev => ({ ...prev, viewMode: 'fileOverview' }));
         } : undefined}

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -927,6 +927,53 @@ td {
   cursor: cell;
 }
 
+/* Virtualized scroll spacers and skeleton cells.
+ *
+ * Spacer rows reserve the height of un-rendered rows above and below the
+ * visible window so the scrollbar maps to the full result set. They must
+ * not have padding/border or hover styling — they are layout only.
+ */
+.virt-spacer {
+  pointer-events: none;
+}
+
+.virt-spacer td {
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: default;
+}
+
+.virt-row {
+  contain: layout;
+}
+
+.virt-row-loading td.cell-loading {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.cell-skeleton {
+  display: inline-block;
+  width: 60%;
+  height: 0.7em;
+  vertical-align: middle;
+  background: linear-gradient(
+    90deg,
+    var(--bg-hover) 0%,
+    var(--bg-surface) 50%,
+    var(--bg-hover) 100%
+  );
+  background-size: 200% 100%;
+  animation: cell-skeleton-shimmer 1.2s ease-in-out infinite;
+  border-radius: 2px;
+}
+
+@keyframes cell-skeleton-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
 tr:hover td:not(.row-number) {
   background: var(--bg-hover);
 }
@@ -1250,6 +1297,29 @@ tr.row-selected td.row-number {
   white-space: pre-wrap;
   word-break: break-word;
   margin: 0;
+}
+
+/* Editable SQL textarea — inherits modal-content sizing */
+.modal-sql-editor {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: var(--space-md);
+  resize: vertical;
+  width: 100%;
+  outline: none;
+  white-space: pre;
+  overflow: auto;
+  min-height: 120px;
+  tab-size: 2;
+}
+
+.modal-sql-editor:focus {
+  border-color: var(--accent-blue);
 }
 
 /* JSON syntax highlighting in modal */

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1011,12 +1011,9 @@ tr:hover td:not(.row-number) {
   font-size: var(--font-size-sm);
 }
 
-/* Row Numbers */
+/* Row Numbers — width is set inline so the column is resizable. */
 .row-number-header,
 .row-number {
-  width: 50px;
-  min-width: 50px;
-  max-width: 50px;
   text-align: right;
   color: var(--text-muted);
   font-size: var(--font-size-sm);
@@ -1024,6 +1021,18 @@ tr:hover td:not(.row-number) {
   user-select: none;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.row-number-header {
+  position: relative;
+}
+
+.row-number-header .resize-handle {
+  /* Same affordance as data-column resize handles. */
+  cursor: col-resize;
 }
 
 .row-number {
@@ -1297,6 +1306,61 @@ tr.row-selected td.row-number {
   white-space: pre-wrap;
   word-break: break-word;
   margin: 0;
+}
+
+/* Editable cell textarea (cell expansion modal in edit mode) */
+.modal-cell-editor {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: var(--space-md);
+  width: 100%;
+  outline: none;
+  resize: vertical;
+  min-height: 80px;
+}
+
+.modal-cell-editor:focus {
+  border-color: var(--accent-blue);
+}
+
+.modal-cell-editor:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.cell-modal-error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-lg);
+  background: rgba(243, 139, 168, 0.08);
+  border-top: 1px solid var(--accent-red);
+  color: var(--accent-red);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}
+
+.cell-modal-error-icon {
+  flex-shrink: 0;
+}
+
+.cell-modal-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--text-muted);
+  border-top-color: var(--accent-blue);
+  border-radius: 50%;
+  animation: cell-modal-spin 0.7s linear infinite;
+}
+
+@keyframes cell-modal-spin {
+  to { transform: rotate(360deg); }
 }
 
 /* Editable SQL textarea — inherits modal-content sizing */

--- a/src/webview/ui/SqlModal.tsx
+++ b/src/webview/ui/SqlModal.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { ExternalLink } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { ExternalLink, Play } from 'lucide-react';
 import { Modal, ModalAction } from './Modal';
 import { SqlSyntaxHighlight } from './SqlHighlight';
 
@@ -10,32 +10,128 @@ export interface SqlModalProps {
   /** "Go to Source File" action — navigates to the original .sql file */
   onGoToSource?: () => void;
   /** "Open in Editor" action — opens the SQL in a new untitled editor */
-  onOpenInEditor?: () => void;
+  onOpenInEditor?: (sql?: string) => void;
+  /**
+   * "Run" action — when provided, the modal becomes an editor and
+   * the user can modify and re-run the SQL with Ctrl/Cmd+Enter.
+   */
+  onRun?: (sql: string) => void;
   title?: string;
 }
 
-export function SqlModal({ sql, onClose, onCopy, onGoToSource, onOpenInEditor, title = "SQL" }: SqlModalProps) {
-  const actions: ModalAction[] = [];
+export function SqlModal({
+  sql,
+  onClose,
+  onCopy,
+  onGoToSource,
+  onOpenInEditor,
+  onRun,
+  title = 'SQL',
+}: SqlModalProps) {
+  const editable = !!onRun;
+  const [draft, setDraft] = useState(sql);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Keep draft in sync if the upstream SQL changes (e.g. filters tweaked)
+  useEffect(() => {
+    setDraft(sql);
+  }, [sql]);
+
+  // Auto-focus the editor when opened so the user can type immediately
+  useEffect(() => {
+    if (editable) {
+      textareaRef.current?.focus();
+      // Place cursor at end
+      const len = textareaRef.current?.value.length ?? 0;
+      textareaRef.current?.setSelectionRange(len, len);
+    }
+  }, [editable]);
+
+  const isDirty = draft !== sql;
+  const trimmed = draft.trim();
+  const canRun = editable && trimmed.length > 0;
+
+  const handleRun = () => {
+    if (!canRun || !onRun) return;
+    onRun(trimmed);
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ctrl/Cmd+Enter runs the query
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleRun();
+      return;
+    }
+    // Tab inserts spaces inside the textarea
+    if (e.key === 'Tab' && !e.shiftKey) {
+      e.preventDefault();
+      const ta = e.currentTarget;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const next = draft.slice(0, start) + '  ' + draft.slice(end);
+      setDraft(next);
+      // Restore cursor after the inserted spaces
+      requestAnimationFrame(() => {
+        ta.setSelectionRange(start + 2, start + 2);
+      });
+    }
+  };
+
+  const actions: ModalAction[] = [];
   if (onGoToSource) {
-    actions.push({ icon: <ExternalLink size={14} />, label: 'Go to Source File', onClick: onGoToSource });
+    actions.push({
+      icon: <ExternalLink size={14} />,
+      label: 'Go to Source File',
+      onClick: onGoToSource,
+    });
   }
   if (onOpenInEditor) {
-    actions.push({ icon: <ExternalLink size={14} />, label: 'Open in Editor', onClick: onOpenInEditor });
+    actions.push({
+      icon: <ExternalLink size={14} />,
+      label: 'Open in Editor',
+      onClick: () => onOpenInEditor(editable ? draft : undefined),
+    });
   }
+  if (canRun) {
+    actions.push({
+      icon: <Play size={14} />,
+      label: isDirty ? 'Run edited SQL (⌘↵)' : 'Run SQL (⌘↵)',
+      onClick: handleRun,
+    });
+  }
+
+  const valueForCopy = editable ? draft : sql;
+  const hint = editable
+    ? 'Edit and press ⌘↵ to run · Esc to close'
+    : 'Press Esc to close';
 
   return (
     <Modal
       title={title}
       onClose={onClose}
-      onCopy={() => onCopy(sql)}
-      size={`${sql.length.toLocaleString()} chars`}
+      onCopy={() => onCopy(valueForCopy)}
+      size={`${valueForCopy.length.toLocaleString()} chars`}
       className="sql-modal"
       actions={actions.length > 0 ? actions : undefined}
+      hint={hint}
     >
-      <pre className="modal-content modal-sql">
-        <SqlSyntaxHighlight sql={sql} />
-      </pre>
+      {editable ? (
+        <textarea
+          ref={textareaRef}
+          className="modal-content modal-sql-editor"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+          rows={Math.min(24, Math.max(6, draft.split('\n').length + 1))}
+        />
+      ) : (
+        <pre className="modal-content modal-sql">
+          <SqlSyntaxHighlight sql={sql} />
+        </pre>
+      )}
     </Modal>
   );
 }


### PR DESCRIPTION
This is a very opinionated PR, reflecting my personal needs. E.g. I like the infinity scroll and to view data (instead of the schema) on file click in VS code. Added the option to modify sql code with one click (seemed broken to me). Updated duckdb too.
No pressure to merge, just thought I'd share. All tested locally on latest VS Code on MacOS. For anyone curious you can install the extension locally from https://github.com/do-me/duckdb-vscode.

- Replace pagination with windowed virtualization (hightable-style): scroll surface sized to totalRows × rowHeight, sticky <thead>, only the rendered slice (+ overscan) lives in the DOM. LRU chunk cache bounded to ~80 chunks so memory stays flat even at 10M rows.
- Drop the LIMIT 1000 default on auto-open; full result set is materialized into a temp table and rows stream in 100-row chunks on demand. New duckdb.fileViewer.openMode (data|schema, default data) and openRowLimit (0 = unlimited) settings; pageSize default
  100. Echo requestVersion in pageData so stale chunks from a prior sort/filter context get dropped.
- Open data files (parquet, csv, json, xlsx single-sheet) directly on the rows view; "Back to Overview" still reaches the schema.
- Make SqlModal editable in every "View SQL" / "SQL Preview" use: ⌘↵ runs the (possibly modified) query, Tab inserts spaces, "Open in Editor" carries the edited text. New runAdHoc IPC handler in overviewHandler and webviewService.
- Refresh button now re-runs the most recent query (default top-N, ad-hoc edit, column selection) instead of dropping back to schema.
- DuckDB spill dir is now per-process (mkdtempSync under os.tmpdir/duckdb-vscode/pid-<pid>-…); removed in close() which deactivate() calls. User-set duckdb.tempDirectory is respected and never deleted.
- Bump @duckdb/node-api 1.4.3-r.3 → 1.5.2-r.1.
- Recovery: when an auto-loaded query errors, show "Back to Schema" so the session isn't stuck on the error screen.
- Cap Cmd+A copy at 10k rows with a -- truncated marker; full exports go through the Copy Table / Export buttons.