### PR TITLE
v0.0.25: fix auto-attach blocking, trailing comments, refresh button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the "duckdb" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.25] - 2026-05-20
+
+### Fixed
+- Opening a CSV (or any data file) no longer blocks for ~75s when a configured remote database (e.g. Postgres) is unreachable. Auto-attach now runs in parallel on isolated connections with a configurable timeout, so a stuck `ATTACH` cannot block extension activation, the main connection, or unrelated file previews.
+- Queries with a trailing `-- comment` on the last line no longer fail with a parser error. The internal `CREATE TEMP TABLE ... AS (...)` wrapper now puts the closing `)` on its own line so it isn't consumed by the line comment ([#6](https://github.com/ChuckJonas/duckdb-vscode/issues/6)).
+- The results panel's Refresh button now re-runs the most recently executed SQL instead of reverting to the SQL from the first run. The cached `queries` array was not being refreshed when a panel was reused for a new run.
+
+### Added
+- New `duckdb.autoAttachTimeoutMs` setting (default `10000`, min `1000`) — how long auto-attach waits for each database on startup before marking it as detached and surfacing a Retry notification.
+
 ## [0.0.24] - 2026-03-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "duckdb",
   "displayName": "DuckDB",
   "description": "A DuckDB client for VS Code — query CSV, Parquet, JSON, and Excel files directly",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "publisher": "chuckjonas",
   "icon": "resources/icon.png",
   "repository": {
@@ -736,6 +736,12 @@
           "type": "string",
           "default": "",
           "description": "Directory for DuckDB temp/spill files. Leave empty to use the OS temp directory."
+        },
+        "duckdb.autoAttachTimeoutMs": {
+          "type": "number",
+          "default": 10000,
+          "minimum": 1000,
+          "description": "Timeout (ms) for auto-attaching each database on startup. If an attach takes longer (e.g. a remote Postgres database while off VPN), it's marked as detached and a notification offers Retry. Does not affect manual attaches."
         },
         "duckdb.resultsLocation": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -288,8 +288,9 @@ export async function activate(context: vscode.ExtensionContext) {
     await migrateExtensionsSetting();
     // Auto-load extensions from workspace settings
     await autoLoadExtensions(db);
-    // Auto-attach databases from workspace settings
-    await autoAttachDatabases(db);
+    // Auto-attach is kicked off further down (fire-and-forget) once the
+    // explorer/status bar exist, so a stuck remote ATTACH can't block
+    // activation or file-viewer previews.
 
     // Initialize query history (optional persistence)
     const historyService = getHistoryService();
@@ -1608,6 +1609,17 @@ export async function activate(context: vscode.ExtensionContext) {
     showCollapseAll: true,
   });
 
+  // Kick off auto-attach in the background. Each attach runs on its own
+  // connection with a timeout, so a stuck remote ATTACH (e.g. Postgres
+  // while off VPN) never blocks activation, the main connection, or the
+  // custom editor that might have triggered activation in the first place.
+  autoAttachDatabases(db, () => {
+    databaseExplorer.refresh();
+    updateStatusBar();
+  }).catch((error) => {
+    console.error("🦆 autoAttachDatabases failed:", error);
+  });
+
   const explorerRefreshCmd = vscode.commands.registerCommand(
     "duckdb.explorer.refresh",
     () => {
@@ -2860,15 +2872,53 @@ export async function deactivate() {
 }
 
 /**
- * Auto-attach databases from workspace settings
- * Only attaches databases that were attached last session (attached !== false)
+ * Race a promise against a timeout. Rejects with a timeout error if
+ * the promise doesn't settle within `ms`. Does NOT cancel the
+ * underlying work (the promise keeps running in the background).
+ */
+function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  message: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/**
+ * Auto-attach databases from workspace settings.
+ *
+ * Each attach runs in parallel on its own throwaway connection, wrapped
+ * in a timeout. A stuck attach (e.g. remote Postgres while off VPN)
+ * therefore cannot block:
+ *   - other attaches
+ *   - the main connection (autocomplete, file viewers, queries)
+ *   - extension activation
+ *
+ * Only attaches databases that were attached last session (attached !== false).
  */
 async function autoAttachDatabases(
-  db: ReturnType<typeof getDuckDBService>
+  db: ReturnType<typeof getDuckDBService>,
+  onAttachStateChanged: () => void
 ): Promise<void> {
   const config = getWorkspaceConfig();
   const databases = config.get<DatabaseConfig[]>("databases", []);
   const defaultDb = config.get<string>("defaultDatabase", "memory");
+  const timeoutMs = Math.max(
+    1000,
+    config.get<number>("autoAttachTimeoutMs", 10000)
+  );
 
   if (databases.length === 0) {
     return;
@@ -2876,96 +2926,37 @@ async function autoAttachDatabases(
 
   const workspaceRoot =
     vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "";
-  const runFn = (sql: string) => db.run(sql);
+
+  const results = await Promise.all(
+    databases.map((dbConfig) =>
+      attachSingleDatabase(
+        db,
+        dbConfig,
+        workspaceRoot,
+        timeoutMs,
+        onAttachStateChanged
+      )
+    )
+  );
+
   let attachedCount = 0;
   let skippedCount = 0;
-
-  for (const dbConfig of databases) {
-    // Only attach if it was attached last session (attached defaults to true for backward compat)
-    if (dbConfig.attached === false) {
-      console.log(`🦆 Skipping "${dbConfig.alias}" (was detached)`);
+  for (const status of results) {
+    if (status === "attached") {
+      attachedCount++;
+    } else if (status === "skipped") {
       skippedCount++;
-      continue;
-    }
-
-    try {
-      switch (dbConfig.type) {
-        case "memory":
-          // In-memory databases are implicit, but we can create named ones
-          if (dbConfig.alias && dbConfig.alias !== "memory") {
-            await attachMemoryDatabase(runFn, dbConfig.alias);
-          }
-          attachedCount++;
-          break;
-
-        case "file": {
-          if (!dbConfig.path) {
-            vscode.window.showWarningMessage(
-              `DuckDB: Database "${dbConfig.alias}" missing path`
-            );
-            continue;
-          }
-
-          // Resolve relative paths from workspace root
-          const filePath = path.isAbsolute(dbConfig.path)
-            ? dbConfig.path
-            : path.resolve(workspaceRoot, dbConfig.path);
-
-          // Check if file exists
-          try {
-            await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
-          } catch {
-            vscode.window.showErrorMessage(
-              `DuckDB: Database file not found: ${dbConfig.path}`
-            );
-            // Mark as detached since we couldn't attach it
-            await updateDatabaseAttachedState(dbConfig.alias, false);
-            continue;
-          }
-
-          await attachDatabase(
-            runFn,
-            filePath,
-            dbConfig.alias,
-            dbConfig.readOnly
-          );
-          attachedCount++;
-          break;
-        }
-
-        case "manual": {
-          if (!dbConfig.sql) {
-            vscode.window.showWarningMessage(
-              `DuckDB: Database "${dbConfig.alias}" missing sql`
-            );
-            continue;
-          }
-          await runManualSql(runFn, dbConfig.sql);
-          attachedCount++;
-          break;
-        }
-
-        default:
-          vscode.window.showWarningMessage(
-            `DuckDB: Unknown database type for "${dbConfig.alias}"`
-          );
-      }
-    } catch (error) {
-      vscode.window.showErrorMessage(
-        `DuckDB: Failed to attach "${dbConfig.alias}": ${error}`
-      );
-      // Mark as detached since we couldn't attach it
-      await updateDatabaseAttachedState(dbConfig.alias, false);
     }
   }
 
-  // Switch to default database (only if it's attached)
+  // Switch to default database (only if it was successfully attached)
   if (defaultDb && defaultDb !== "memory") {
     try {
-      await switchDatabase(runFn, defaultDb);
+      await switchDatabase(async (sql) => db.run(sql), defaultDb);
       currentDatabase = defaultDb;
+      onAttachStateChanged();
     } catch (error) {
-      // Default database might not be attached, that's okay
+      // Default database might not be attached (timeout, unreachable, etc.)
       console.log(
         `🦆 Could not switch to default database "${defaultDb}": ${error}`
       );
@@ -2976,6 +2967,131 @@ async function autoAttachDatabases(
     console.log(
       `🦆 Auto-attached ${attachedCount} database(s), skipped ${skippedCount}`
     );
+  }
+}
+
+type AttachStatus = "attached" | "skipped" | "failed";
+
+/**
+ * Attach a single database on its own throwaway connection so a slow
+ * attach (e.g. remote Postgres) doesn't block the main connection.
+ */
+async function attachSingleDatabase(
+  db: ReturnType<typeof getDuckDBService>,
+  dbConfig: DatabaseConfig,
+  workspaceRoot: string,
+  timeoutMs: number,
+  onAttachStateChanged: () => void
+): Promise<AttachStatus> {
+  if (dbConfig.attached === false) {
+    console.log(`🦆 Skipping "${dbConfig.alias}" (was detached)`);
+    return "skipped";
+  }
+
+  // Validate config before doing any async work
+  if (dbConfig.type === "file" && !dbConfig.path) {
+    vscode.window.showWarningMessage(
+      `DuckDB: Database "${dbConfig.alias}" missing path`
+    );
+    return "failed";
+  }
+  if (dbConfig.type === "manual" && !dbConfig.sql) {
+    vscode.window.showWarningMessage(
+      `DuckDB: Database "${dbConfig.alias}" missing sql`
+    );
+    return "failed";
+  }
+
+  // For file databases, check existence up front — cheaper than waiting
+  // on ATTACH to fail, and lets us give a precise error message.
+  let resolvedFilePath: string | undefined;
+  if (dbConfig.type === "file" && dbConfig.path) {
+    resolvedFilePath = path.isAbsolute(dbConfig.path)
+      ? dbConfig.path
+      : path.resolve(workspaceRoot, dbConfig.path);
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.file(resolvedFilePath));
+    } catch {
+      vscode.window.showErrorMessage(
+        `DuckDB: Database file not found: ${dbConfig.path}`
+      );
+      await updateDatabaseAttachedState(dbConfig.alias, false);
+      return "failed";
+    }
+  }
+
+  let conn: { run: (sql: string) => Promise<void>; close: () => void };
+  try {
+    conn = await db.createConnection();
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `DuckDB: Failed to open connection for "${dbConfig.alias}": ${error}`
+    );
+    return "failed";
+  }
+
+  try {
+    const attachTask = (async () => {
+      switch (dbConfig.type) {
+        case "memory":
+          if (dbConfig.alias && dbConfig.alias !== "memory") {
+            await conn.run(`ATTACH ':memory:' AS "${dbConfig.alias}"`);
+          }
+          break;
+
+        case "file": {
+          const mode = dbConfig.readOnly ? " (READ_ONLY)" : "";
+          const escapedPath = (resolvedFilePath as string).replace(/'/g, "''");
+          await conn.run(
+            `ATTACH '${escapedPath}' AS "${dbConfig.alias}"${mode}`
+          );
+          break;
+        }
+
+        case "manual":
+          await conn.run(dbConfig.sql as string);
+          break;
+
+        default:
+          throw new Error(`Unknown database type: ${dbConfig.type}`);
+      }
+    })();
+
+    await withTimeout(
+      attachTask,
+      timeoutMs,
+      `__attach_timeout__:${dbConfig.alias}`
+    );
+
+    onAttachStateChanged();
+    return "attached";
+  } catch (error) {
+    const errMessage = error instanceof Error ? error.message : String(error);
+    const isTimeout = errMessage.startsWith("__attach_timeout__:");
+
+    const message = isTimeout
+      ? `DuckDB: Auto-attach timed out for "${dbConfig.alias}" after ${timeoutMs}ms (check VPN/network). Marked as detached.`
+      : `DuckDB: Failed to attach "${dbConfig.alias}": ${errMessage}`;
+
+    // Non-blocking notification with a Retry affordance.
+    vscode.window
+      .showWarningMessage(message, "Retry", "Open Settings")
+      .then((choice) => {
+        if (choice === "Retry") {
+          vscode.commands.executeCommand("duckdb.selectDatabase");
+        } else if (choice === "Open Settings") {
+          vscode.commands.executeCommand(
+            "workbench.action.openSettings",
+            "duckdb.databases"
+          );
+        }
+      });
+
+    await updateDatabaseAttachedState(dbConfig.alias, false);
+    onAttachStateChanged();
+    return "failed";
+  } finally {
+    conn.close();
   }
 }
 

--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -518,8 +518,12 @@ export class DuckDBService {
     const cacheId = this.generateCacheId();
 
     try {
-      // Create temp table with results
-      const createSql = `CREATE TEMP TABLE "${cacheId}" AS (${sql})`;
+      // Create temp table with results.
+      // The newlines around `sql` are load-bearing: if the user's last line
+      // ends in a `-- comment`, putting the closing `)` on the same line
+      // would make it part of the comment and break the query.
+      // See: https://github.com/ChuckJonas/duckdb-vscode/issues/6
+      const createSql = `CREATE TEMP TABLE "${cacheId}" AS (\n${sql}\n)`;
       await this.connection.run(createSql);
       this.activeCaches.add(cacheId);
 
@@ -1336,6 +1340,41 @@ export class DuckDBService {
     for (const cacheId of caches) {
       await this.dropCache(cacheId);
     }
+  }
+
+  /**
+   * Create a new connection on the shared DuckDB instance.
+   *
+   * ATTACH state is instance-wide, so running ATTACH on a throwaway
+   * connection still exposes the database to the main connection.
+   * Use this to isolate potentially slow operations (e.g. a remote
+   * Postgres ATTACH) that would otherwise block the main connection
+   * while they stall on network I/O.
+   *
+   * Callers MUST call close() in a finally block.
+   */
+  async createConnection(): Promise<{
+    run: (sql: string) => Promise<void>;
+    close: () => void;
+  }> {
+    await this.initialize();
+    if (!this.instance) {
+      throw new Error("DuckDB instance not available");
+    }
+
+    const conn = await this.instance.connect();
+    return {
+      run: async (sql: string) => {
+        await conn.run(sql);
+      },
+      close: () => {
+        try {
+          conn.closeSync();
+        } catch {
+          // Connection may already be closed
+        }
+      },
+    };
   }
 
   /**

--- a/src/services/webviewService.ts
+++ b/src/services/webviewService.ts
@@ -235,12 +235,15 @@ function tryReuseExistingPanel(
       db.dropCache(cacheId).catch(() => {});
     }
 
-    // Update state
+    // Update state. `queries` must be refreshed too — otherwise the
+    // panel's "Refresh" button would re-run the SQL from the very first
+    // execution instead of the latest one the user just ran.
     state.panel.title = title;
     state.cacheIds = cacheIds;
     state.currentResult = result;
     state.sortColumn = undefined;
     state.sortDirection = undefined;
+    state.queries = result.statements.map((s) => s.meta.sql);
 
     // Reveal in current location (don't move the panel)
     state.panel.reveal();


### PR DESCRIPTION
## Summary
- **Auto-attach no longer blocks file viewers / activation** — opening a CSV in a workspace with an unreachable remote database (e.g. Postgres while off VPN) used to stall the extension host for ~75s because auto-attach ran sequentially on the main connection. Now each database attaches in parallel on its own throwaway connection, wrapped in a configurable timeout (`duckdb.autoAttachTimeoutMs`, default 10s). On timeout the DB is marked detached and a notification offers Retry / Open Settings.
- **Trailing `-- comment` on the last line of a query no longer errors** ([#6](https://github.com/ChuckJonas/duckdb-vscode/issues/6)) — the internal `CREATE TEMP TABLE x AS (...)` cache wrapper was placing the closing `)` on the same line as the user's trailing line comment, making it part of the comment. Fixed by surrounding the wrapped SQL with newlines.
- **Results panel Refresh button no longer reverts to the original SQL** — when a panel was reused for a re-run, `state.queries` wasn't being refreshed alongside `cacheIds` / `currentResult`, so clicking Refresh in the panel re-executed the first-ever SQL instead of the latest.

Made with [Cursor](https://cursor.com)