### PR TITLE
v0.0.27: read-only SQL preview, panel reuse, DuckDB 1.5.3, large-result scroll fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [0.0.27] - 2026-05-31
+
+### Changed
+- **SQL preview modals are read-only again; editing happens in a real editor.** The in-panel SQL editor introduced in 0.0.26 is removed — the "View SQL" / "SQL Preview" modal is now a syntax-highlighted, read-only preview. Use **Open in Editor** (or **Go to Source File**) to edit the query in a first-class SQL editor with highlighting, completion, and error reporting. The separate filtered/sorted "View Query" modal is folded into the single SQL modal behind an **Apply filters & sort** toggle (shown only when a filter or sort is active), and the standalone "SQL" badge in the stats bar is removed.
+- **Running a query opened from the data viewer reuses its panel.** When you "Open in Editor" from a file or table overview and run the resulting SQL, the results now replace the originating viewer panel instead of spawning a separate results tab.
+- Bumped `@duckdb/node-api` from `1.5.2-r.1` to `1.5.3-r.2` (DuckDB engine v1.5.3).
+
+### Fixed
+- **Infinite scroll could not reach rows past ~883k** in large results ([#10](https://github.com/ChuckJonas/duckdb-vscode/issues/10)). The virtualized scroll surface exceeded the browser's maximum element height (2^24 px), clamping everything beyond it out of reach. The surface is now capped below that ceiling and scaled, so every row in multi-million-row results is reachable. Below ~420k rows scrolling is unchanged (1:1); above it the scrollbar maps proportionally onto the full result set. Also disabled browser scroll anchoring on the results viewport to prevent a scroll feedback loop.
+- **Editing the query inline in the results panel did not update the view** and reset the horizontal scroll position ([#12](https://github.com/ChuckJonas/duckdb-vscode/issues/12)). Inline query editing is removed in favor of editing in a real SQL editor, which eliminates both the stale-view and scroll-reset behavior.
+
+## [0.0.26] - 2026-05-20
+
 ### Added
 - **Editable SQL modal** — every "View SQL" / "SQL Preview" modal is now a SQL editor: tweak the query and press ⌘↵ / Ctrl+↵ to run it in place. Works for the file overview preview, the original-query modal in the results table, and the filtered/sorted full-query modal. "Open in Editor" now uses the edited text. Tab inserts spaces.
 - New `duckdb.fileViewer.openMode` setting (`data` | `schema`, default `schema`) and `duckdb.fileViewer.openRowLimit` (default `0` = unlimited). Set `openMode` to `"data"` to jump straight into rows on file open — useful for smaller files or when you prefer immediate data access.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-api": "^1.5.2-r.1",
+        "@duckdb/node-api": "^1.5.3-r.2",
         "fzf": "^0.5.2",
         "lucide-react": "^0.563.0",
         "react": "^19.2.3",
@@ -258,32 +258,37 @@
       }
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.2-r.1.tgz",
-      "integrity": "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.3-r.2.tgz",
+      "integrity": "sha512-xjn6W9n8Sn9PaYmzrB6ayidNLQHpqNKdaRz4gx3yVoLUkrsIebQC1M1jV3BR8KqXj5P0RX4wLs8Tg/fK2ZQmNA==",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-bindings": "1.5.2-r.1"
+        "@duckdb/node-bindings": "1.5.3-r.2"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.2-r.1.tgz",
-      "integrity": "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.3-r.2.tgz",
+      "integrity": "sha512-bveKx+LfqRazcH8/MuCkMsbLVQKqr/EyuYRzaKpBcEvRYenw/TqK5+1N4fkMyoTv8ZukA4UYobymNYHqJUpdOA==",
       "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1",
-        "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1",
-        "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1",
-        "@duckdb/node-bindings-linux-x64": "1.5.2-r.1",
-        "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1",
-        "@duckdb/node-bindings-win32-x64": "1.5.2-r.1"
+        "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.2",
+        "@duckdb/node-bindings-darwin-x64": "1.5.3-r.2",
+        "@duckdb/node-bindings-linux-arm64": "1.5.3-r.2",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.2",
+        "@duckdb/node-bindings-linux-x64": "1.5.3-r.2",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.2",
+        "@duckdb/node-bindings-win32-arm64": "1.5.3-r.2",
+        "@duckdb/node-bindings-win32-x64": "1.5.3-r.2"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.2-r.1.tgz",
-      "integrity": "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.3-r.2.tgz",
+      "integrity": "sha512-5RQ3+fUZn+OvIJEfa1i/KngJHo5d6ilpjunsHfHdQy5F7r5pewDkPxRQno4xInPqGukMibKDoMdpzCKnymFJtw==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +299,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.2-r.1.tgz",
-      "integrity": "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.3-r.2.tgz",
+      "integrity": "sha512-E7Pc+do8kj82+hHXkp4mxfw9Kqfe6V5FUT2EMoRsacbvhuoM1AeZxOj9jknh23IoNxPtn3S2tKnD1krL0v0I7A==",
       "cpu": [
         "x64"
       ],
@@ -307,9 +312,22 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.2-r.1.tgz",
-      "integrity": "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.3-r.2.tgz",
+      "integrity": "sha512-R8RKkNgVL4kHodot1krfbB4XQ+bA90LPsnN1Lm5J03QJlFgNlezul0H2U1UuvEaKUBPWDQj8g9Yt4hhKKKX0zw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64-musl": {
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.3-r.2.tgz",
+      "integrity": "sha512-P9lTyML8M6pS300fJbnMNFSBhojC0xJcvGvuR44xd//NqaHk9EwcPIs4+r2ek4LP5uugm7konVZ3VMr0BOKujw==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +338,22 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.2-r.1.tgz",
-      "integrity": "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.3-r.2.tgz",
+      "integrity": "sha512-6vYTXgIqnWEjlNZX/AveTU7EzicuGATOdy8ncUbBIDxoC9cIrjoIqQc37COKEyT5IHjLIt25MllJtags96vvxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64-musl": {
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.3-r.2.tgz",
+      "integrity": "sha512-V9kPvbMoJENvPo82LOzfhZ+KilFe1K8TKrksFmHe1Sy2pduNUVnxC+T4OQuOu4sqyCCVqVYRXe3pqTzKa/hCYg==",
       "cpu": [
         "x64"
       ],
@@ -333,9 +364,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-arm64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.2-r.1.tgz",
-      "integrity": "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.3-r.2.tgz",
+      "integrity": "sha512-CjKqTI0WfRxwLgz8FV4fej/wkijPQnRgDk93aQlWQ+/+EwB9EnwQW3yfUy4Rs8cFjQkxkwlL5azoSR973l8U6w==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +377,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.2-r.1.tgz",
-      "integrity": "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==",
+      "version": "1.5.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.3-r.2.tgz",
+      "integrity": "sha512-/oxN8ZFf2LxhForL+Uc+lEqnzHNvhSEsu3blnk3zu73rKTbD/WvPYIecrenb1ysApRK9ElGxitIYFx8PBuVKxg==",
       "cpu": [
         "x64"
       ],
@@ -3047,9 +3078,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "duckdb",
   "displayName": "DuckDB",
   "description": "A DuckDB client for VS Code — query CSV, Parquet, JSON, and Excel files directly",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publisher": "chuckjonas",
   "icon": "resources/icon.png",
   "repository": {
@@ -953,7 +953,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@duckdb/node-api": "^1.5.2-r.1",
+    "@duckdb/node-api": "^1.5.3-r.2",
     "fzf": "^0.5.2",
     "lucide-react": "^0.563.0",
     "react": "^19.2.3",

--- a/src/providers/overviewHandler.ts
+++ b/src/providers/overviewHandler.ts
@@ -12,7 +12,11 @@ import {
   collectCacheIds,
   type MultiQueryResultWithPages,
 } from "../services/duckdb";
-import { handleExport } from "../services/webviewService";
+import {
+  handleExport,
+  linkAdHocEditor,
+  unlinkAdHocEditor,
+} from "../services/webviewService";
 import type {
   DataOverviewMetadata,
   ContainerOverviewMetadata,
@@ -102,7 +106,7 @@ export function setupOverviewWebview(
   let cacheIds: string[] = [];
   let sortColumn: string | undefined;
   let sortDirection: "asc" | "desc" | undefined;
-  // The most recently executed query (default top-N, queryFile, or runAdHoc).
+  // The most recently executed query (default top-N or queryFile).
   // Used so "refresh" re-runs the last query rather than dropping back to
   // the schema overview.
   let lastQuerySql: string | undefined;
@@ -113,6 +117,9 @@ export function setupOverviewWebview(
    * projections, LIMITed samples, and ad-hoc SQL.
    */
   let cacheIsFullSource = false;
+  // Docs spawned via "Open in Editor"; running them routes results here.
+  const linkedDocs = new Set<string>();
+  let closeListener: vscode.Disposable | undefined;
 
   // Set up webview options and content
   panel.webview.options = {
@@ -133,11 +140,16 @@ export function setupOverviewWebview(
   );
   panel.webview.html = getWebviewHtml(scriptUri);
 
-  // Clean up DuckDB caches when the editor is closed
+  // Clean up DuckDB caches and any ad-hoc editor links when the editor closes
   panel.onDidDispose(() => {
     for (const id of cacheIds) {
       db.dropCache(id).catch(() => {});
     }
+    for (const docUri of linkedDocs) {
+      unlinkAdHocEditor(docUri);
+    }
+    linkedDocs.clear();
+    closeListener?.dispose();
   });
 
   // ------------------------------------------------------------------
@@ -219,6 +231,47 @@ export function setupOverviewWebview(
   }
 
   // ------------------------------------------------------------------
+  // Display a pre-computed result (run from a linked "Open in Editor"
+  // doc) inside this panel, adopting its caches rather than re-running.
+  // ------------------------------------------------------------------
+  function displayExternalResult(
+    result: MultiQueryResultWithPages,
+    resultPageSize: number,
+    resultMaxCopyRows: number
+  ): void {
+    resetCaches();
+    cacheIds = collectCacheIds(result);
+    // So the panel's "Refresh" re-runs the edited query, not the source view.
+    lastQuerySql = result.statements.map((s) => s.meta.sql).join(";\n");
+    // Ad-hoc / derived results are never safe to write back to the source.
+    cacheIsFullSource = false;
+    // Surface the panel but keep focus on the editor the user ran from.
+    panel.reveal(undefined, true);
+    panel.webview.postMessage({
+      type: "queryResult",
+      data: result,
+      pageSize: resultPageSize,
+      maxCopyRows: resultMaxCopyRows,
+      editable: false,
+    });
+  }
+
+  function linkEditorDoc(doc: vscode.TextDocument): void {
+    const key = doc.uri.toString();
+    linkedDocs.add(key);
+    linkAdHocEditor(key, { panel, display: displayExternalResult });
+    // Lazily wire a close listener so reused untitled URIs don't leak links.
+    if (!closeListener) {
+      closeListener = vscode.workspace.onDidCloseTextDocument((closed) => {
+        const closedKey = closed.uri.toString();
+        if (linkedDocs.delete(closedKey)) {
+          unlinkAdHocEditor(closedKey);
+        }
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------
   // Message handler
   // ------------------------------------------------------------------
   panel.webview.onDidReceiveMessage(async (message) => {
@@ -265,13 +318,7 @@ export function setupOverviewWebview(
         await vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,
         });
-        break;
-      }
-
-      case "runAdHoc": {
-        if (typeof message.sql !== "string" || !message.sql.trim()) break;
-        // Ad-hoc edits produce a derived result; never safe to write back.
-        await runQuery(message.sql, "Running query…", { editable: false });
+        linkEditorDoc(doc);
         break;
       }
 
@@ -503,9 +550,22 @@ export function setupOverviewWebview(
         }
         break;
 
-      case "goToSource":
-        // No-op in overview mode — there is no source file to navigate to.
+      case "goToSource": {
+        // File-overview panels have no source .sql file. The webview's
+        // "Open in Editor" affordance still hands the user off here for
+        // the source-query view of the modal; treat that as "open the
+        // current query as an untitled .sql doc."
+        const sql = lastQuerySql ?? source.buildSelectSql();
+        const doc = await vscode.workspace.openTextDocument({
+          content: sql,
+          language: "sql",
+        });
+        await vscode.window.showTextDocument(doc, {
+          viewColumn: vscode.ViewColumn.Beside,
+        });
+        linkEditorDoc(doc);
         break;
+      }
     }
   });
 }
@@ -547,6 +607,9 @@ export function setupMultiTableOverviewWebview(
   let sortDirection: "asc" | "desc" | undefined;
   let activeSource: OverviewDataSource | null = null;
   let containerMeta: ContainerOverviewMetadata | null = null;
+  // Docs spawned via "Open in Editor"; running them routes results here.
+  const linkedDocs = new Set<string>();
+  let closeListener: vscode.Disposable | undefined;
 
   panel.webview.options = {
     enableScripts: true,
@@ -570,10 +633,48 @@ export function setupMultiTableOverviewWebview(
     for (const id of cacheIds) {
       db.dropCache(id).catch(() => {});
     }
+    for (const docUri of linkedDocs) {
+      unlinkAdHocEditor(docUri);
+    }
+    linkedDocs.clear();
+    closeListener?.dispose();
   });
 
   function sendLoadingStatus(message: string): void {
     panel.webview.postMessage({ type: "loadingStatus", message });
+  }
+
+  // Display a pre-computed result (run from a linked "Open in Editor" doc)
+  // inside this panel. Multi-table sources (xlsx) are never write-back.
+  function displayExternalResult(
+    result: MultiQueryResultWithPages,
+    resultPageSize: number,
+    resultMaxCopyRows: number
+  ): void {
+    resetCaches();
+    cacheIds = collectCacheIds(result);
+    panel.reveal(undefined, true);
+    panel.webview.postMessage({
+      type: "queryResult",
+      data: result,
+      pageSize: resultPageSize,
+      maxCopyRows: resultMaxCopyRows,
+      editable: false,
+    });
+  }
+
+  function linkEditorDoc(doc: vscode.TextDocument): void {
+    const key = doc.uri.toString();
+    linkedDocs.add(key);
+    linkAdHocEditor(key, { panel, display: displayExternalResult });
+    if (!closeListener) {
+      closeListener = vscode.workspace.onDidCloseTextDocument((closed) => {
+        const closedKey = closed.uri.toString();
+        if (linkedDocs.delete(closedKey)) {
+          unlinkAdHocEditor(closedKey);
+        }
+      });
+    }
   }
 
   async function sendContainerMetadata(): Promise<void> {
@@ -689,30 +790,7 @@ export function setupMultiTableOverviewWebview(
         await vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,
         });
-        break;
-      }
-
-      case "runAdHoc": {
-        try {
-          if (typeof message.sql !== "string" || !message.sql.trim()) break;
-          sendLoadingStatus("Running query…");
-          resetCaches();
-          const result = await db.executeQuery(message.sql, pageSize);
-          cacheIds = collectCacheIds(result);
-          panel.webview.postMessage({
-            type: "queryResult",
-            data: result,
-            pageSize,
-            maxCopyRows,
-            // Multi-table sources (xlsx) never support write-back.
-            editable: false,
-          });
-        } catch (error) {
-          panel.webview.postMessage({
-            type: "queryError",
-            error: String(error),
-          });
-        }
+        linkEditorDoc(doc);
         break;
       }
 
@@ -900,8 +978,24 @@ export function setupMultiTableOverviewWebview(
         }
         break;
 
-      case "goToSource":
+      case "goToSource": {
+        // Multi-table panels (xlsx etc.) have no source .sql file.
+        // Treat the webview's "Open in Editor" hand-off as "open the
+        // current sheet's default SELECT as an untitled .sql doc."
+        if (!activeSource) {
+          break;
+        }
+        const sql = activeSource.buildSelectSql();
+        const doc = await vscode.workspace.openTextDocument({
+          content: sql,
+          language: "sql",
+        });
+        await vscode.window.showTextDocument(doc, {
+          viewColumn: vscode.ViewColumn.Beside,
+        });
+        linkEditorDoc(doc);
         break;
+      }
     }
   });
 }

--- a/src/services/webviewService.ts
+++ b/src/services/webviewService.ts
@@ -23,6 +23,40 @@ interface PanelState {
 
 const resultPanels = new Map<string, PanelState>();
 
+/**
+ * A linked "ad-hoc" SQL editor: an untitled .sql doc spawned via the
+ * overview panel's "Open in Editor" action. Running such a doc routes
+ * its results back into the originating overview panel (a custom-editor
+ * webview) instead of spawning a separate results panel.
+ */
+interface AdHocEditorTarget {
+  panel: vscode.WebviewPanel;
+  display: (
+    result: MultiQueryResultWithPages,
+    pageSize: number,
+    maxCopyRows: number
+  ) => void;
+}
+
+// Keyed by the editor document URI string (e.g. "untitled:Untitled-1").
+const adHocEditorLinks = new Map<string, AdHocEditorTarget>();
+
+/**
+ * Link an editor doc to the overview panel it was spawned from, so that
+ * running the doc displays its results inside that panel.
+ */
+export function linkAdHocEditor(
+  docUri: string,
+  target: AdHocEditorTarget
+): void {
+  adHocEditorLinks.set(docUri, target);
+}
+
+/** Remove a previously-registered ad-hoc editor link. */
+export function unlinkAdHocEditor(docUri: string): void {
+  adHocEditorLinks.delete(docUri);
+}
+
 // Track the currently active results panel for "Go to Source" command
 let activeResultsSourceUri: vscode.Uri | undefined;
 let activeResultsQueries: string[] = [];
@@ -67,6 +101,23 @@ export function showResultsPanel(
   pageSize: number,
   maxCopyRows: number
 ): void {
+  // If this run came from an editor that was spawned by an overview
+  // panel's "Open in Editor", route the result back into that panel
+  // instead of creating a separate results panel.
+  if (sourceId) {
+    const link = adHocEditorLinks.get(sourceId);
+    if (link) {
+      try {
+        link.display(result, pageSize, maxCopyRows);
+        return;
+      } catch {
+        // The linked panel was disposed; drop the stale link and fall
+        // through to the normal results-panel flow.
+        adHocEditorLinks.delete(sourceId);
+      }
+    }
+  }
+
   // If no statement produces tabular results (all DDL/DML), skip the panel.
   // Show a subtle status bar message as fallback for call sites without an editor
   // (e.g. history re-run). Call sites with an editor show inline decorations instead.
@@ -405,15 +456,8 @@ function setupMessageHandler(
           await handleRefreshQuery(panel, sourceId, pageSize, maxCopyRows, db);
           break;
 
-        case "runAdHoc":
-          await handleRunAdHoc(
-            panel,
-            sourceId,
-            message.sql,
-            pageSize,
-            maxCopyRows,
-            db
-          );
+        case "openAsSql":
+          await handleOpenAsSql(message.sql);
           break;
 
         case "goToSource":
@@ -708,53 +752,23 @@ async function handleRefreshQuery(
 }
 
 /**
- * Handle 'runAdHoc' message - execute SQL edited in the SQL modal,
- * replacing the current results in this panel. The new SQL becomes
- * the panel's stored query, so subsequent refreshes re-run it.
+ * Handle 'openAsSql' message — drop the user into a new untitled .sql
+ * editor pre-filled with the provided SQL. Used by the "View Query"
+ * modal in ResultsTable so a user can pick up the current query
+ * (including UI filters / sort) and keep iterating on it in a real
+ * editor instead of a textarea inside the webview.
  */
-async function handleRunAdHoc(
-  panel: vscode.WebviewPanel,
-  sourceId: string | undefined,
-  sql: unknown,
-  pageSize: number,
-  maxCopyRows: number,
-  db: ReturnType<typeof getDuckDBService>
-): Promise<void> {
-  if (typeof sql !== "string" || !sql.trim()) return;
-
-  const currentState = sourceId ? resultPanels.get(sourceId) ?? null : null;
-
-  try {
-    if (currentState) {
-      for (const cacheId of currentState.cacheIds) {
-        db.dropCache(cacheId).catch(() => {});
-      }
-    }
-
-    const result = await db.executeQuery(sql, pageSize);
-
-    if (currentState) {
-      const newCacheIds = collectCacheIds(result);
-      currentState.cacheIds = newCacheIds;
-      currentState.currentResult = result;
-      currentState.sortColumn = undefined;
-      currentState.sortDirection = undefined;
-      currentState.queries = result.statements.map((s) => s.meta.sql);
-      panel.title = buildPanelTitle(result);
-    }
-
-    panel.webview.postMessage({
-      type: "queryResult",
-      data: result,
-      pageSize,
-      maxCopyRows,
-    });
-  } catch (error) {
-    panel.webview.postMessage({
-      type: "refreshError",
-      error: String(error),
-    });
+async function handleOpenAsSql(sql: unknown): Promise<void> {
+  if (typeof sql !== "string" || !sql.trim()) {
+    return;
   }
+  const doc = await vscode.workspace.openTextDocument({
+    content: sql,
+    language: "sql",
+  });
+  await vscode.window.showTextDocument(doc, {
+    viewColumn: vscode.ViewColumn.Beside,
+  });
 }
 
 // ============================================================================

--- a/src/webview/FileOverview.tsx
+++ b/src/webview/FileOverview.tsx
@@ -235,18 +235,12 @@ export function FileOverview({ metadata, onBackToContainer }: FileOverviewProps)
     });
   }, [selectedColumnNames, noneSelected]);
 
-  const handleOpenAsSql = useCallback((sql?: string) => {
+  const handleOpenAsSql = useCallback((sql: string) => {
     const vscode = getVscodeApi();
     vscode.postMessage({
       type: 'openAsSql',
-      columns: selectedColumnNames,
       sql,
     });
-  }, [selectedColumnNames]);
-
-  const handleRunAdHoc = useCallback((sql: string) => {
-    const vscode = getVscodeApi();
-    vscode.postMessage({ type: 'runAdHoc', sql });
   }, []);
 
   const handleCopySql = useCallback((text: string) => {
@@ -451,14 +445,14 @@ export function FileOverview({ metadata, onBackToContainer }: FileOverviewProps)
         </code>
       </div>
 
-      {/* SQL Modal — editable; ⌘↵ runs the (possibly modified) query */}
+      {/* SQL Preview — read-only; "Open in Editor" hands off to an
+          untitled .sql doc for actual editing. */}
       {showSqlModal && (
         <SqlModal
           sql={sqlPreview}
           onClose={() => setShowSqlModal(false)}
           onCopy={handleCopySql}
           onOpenInEditor={handleOpenAsSql}
-          onRun={handleRunAdHoc}
           title="SQL Preview"
         />
       )}

--- a/src/webview/ResultsTable.tsx
+++ b/src/webview/ResultsTable.tsx
@@ -15,7 +15,7 @@ import {
 } from './ui/FilterBar';
 import { ColumnFilterPopover } from './ui/ColumnFilterPopover';
 import { formatValue, formatTableAsText } from './utils/format';
-import { Copy, Download, ExternalLink, ChevronDown, Filter, Code, BarChart2, ArrowUp, ArrowDown, ChevronsUpDown, RefreshCw, Save } from 'lucide-react';
+import { Copy, Download, ExternalLink, ChevronDown, Filter, BarChart2, ArrowUp, ArrowDown, ChevronsUpDown, RefreshCw, Save } from 'lucide-react';
 import { CopyButton } from './ui/CopyButton';
 import { IconButton } from './ui/IconButton';
 import { PopoverMenu } from './ui/PopoverMenu';
@@ -41,6 +41,21 @@ const OVERSCAN_ROWS = 40;
  * evicted when this is exceeded. 80 chunks * 100 rows ≈ 8k rows resident.
  */
 const MAX_CACHED_CHUNKS = 80;
+/**
+ * Browsers cap the rendered pixel height of a single element. In the Chromium
+ * build backing the VS Code webview that ceiling is 2^24 = 16,777,216px
+ * (elements taller than this are silently clamped, which would map the full
+ * scrollbar onto only part of the data). A naive `totalRows * rowHeight`
+ * scroll surface hits this around ~440k rows at ~38px/row, leaving everything
+ * past it unreachable (issue #10).
+ *
+ * We keep the scroll surface safely under that ceiling and, when the ideal
+ * height exceeds it, compress: DOM scroll is scaled up to a virtual scroll
+ * position so the full result set stays reachable (the scrollbar just becomes
+ * coarser the larger the result). Staying strictly below 2^24 guarantees the
+ * browser never clamps, so the scaled mapping is exact end-to-end.
+ */
+const MAX_SCROLL_SURFACE = 16_000_000;
 
 // ============================================================================
 // RESULTS TABLE - Display component for a single statement's results
@@ -135,7 +150,6 @@ export function ResultsTable({
 
   // ---- Misc UI state ----
   const [showSqlModal, setShowSqlModal] = useState(false);
-  const [showFullSqlModal, setShowFullSqlModal] = useState(false);
   /**
    * Column widths. Keyed by column name. The synthetic key `__rownum__`
    * holds the user-overridden width of the row-number gutter; if absent,
@@ -278,14 +292,48 @@ export function ResultsTable({
 
   // --------------------------------------------------------------------------
   // Compute the visible row range and which chunks back it.
+  //
+  // The scroll surface is capped at MAX_SCROLL_SURFACE so it never exceeds the
+  // browser's max element height (issue #10). When the ideal height
+  // (filteredRowCount * rowHeight) fits under the cap, `scrollScale === 1` and
+  // this is a plain 1:1 virtualization. When it doesn't, the DOM scrollTop is
+  // linearly scaled up to a "virtual" scroll position so every row stays
+  // reachable, and the rendered slice is positioned to track the viewport.
   // --------------------------------------------------------------------------
   const visibleHeight = Math.max(0, viewportHeight - headerHeight);
-  const firstVisible = Math.max(0, Math.floor(scrollTop / rowHeight));
-  const lastVisible = Math.min(filteredRowCount, Math.ceil((scrollTop + visibleHeight) / rowHeight));
-  const renderStart = Math.max(0, firstVisible - OVERSCAN_ROWS);
+  const idealTotalHeight = filteredRowCount * rowHeight;
+  const scrollSurfaceHeight = Math.min(idealTotalHeight, MAX_SCROLL_SURFACE);
+  // The DOM's scrollTop range and the virtual (ideal) scroll range. Their
+  // ratio is the compression factor (>= 1; exactly 1 when not compressed).
+  const domScrollRange = Math.max(1, scrollSurfaceHeight - visibleHeight);
+  const virtualScrollRange = Math.max(0, idealTotalHeight - visibleHeight);
+  const scrollScale = virtualScrollRange / domScrollRange;
+  const virtualScrollTop = Math.min(virtualScrollRange, scrollTop * scrollScale);
+
+  const firstVisible = Math.max(0, Math.floor(virtualScrollTop / rowHeight));
+  const lastVisible = Math.min(
+    filteredRowCount,
+    Math.ceil((virtualScrollTop + visibleHeight) / rowHeight)
+  );
+  // Fractional (sub-row) part of the scroll position at the viewport top.
+  const fractional = virtualScrollTop - firstVisible * rowHeight;
+  // Cap overscan above the first visible row so the top spacer never goes
+  // negative under compression (which would misalign the rendered slice).
+  const aboveCapacity = Math.floor(Math.max(0, scrollTop - fractional) / rowHeight);
+  const overscanAbove = Math.min(OVERSCAN_ROWS, aboveCapacity);
+  const renderStart = Math.max(0, firstVisible - overscanAbove);
   const renderEnd = Math.min(filteredRowCount, lastVisible + OVERSCAN_ROWS);
-  const topSpacerHeight = renderStart * rowHeight;
-  const bottomSpacerHeight = Math.max(0, (filteredRowCount - renderEnd) * rowHeight);
+  // Position the rendered slice at the current scroll position. In the
+  // non-compressed case this reduces exactly to `renderStart * rowHeight`.
+  const renderedHeight = (renderEnd - renderStart) * rowHeight;
+  const topSpacerHeight = Math.max(
+    0,
+    scrollTop - fractional - (firstVisible - renderStart) * rowHeight
+  );
+  const bottomSpacerHeight = Math.max(
+    0,
+    scrollSurfaceHeight - topSpacerHeight - renderedHeight
+  );
 
   // --------------------------------------------------------------------------
   // Helper: build the active where clause from filter state.
@@ -634,14 +682,24 @@ export function ResultsTable({
     getVscodeApi()?.postMessage({ type: 'refreshQuery' });
   }, [isRefreshing]);
 
-  const handleGoToSource = useCallback(() => {
-    getVscodeApi()?.postMessage({ type: 'goToSource' });
-  }, []);
-
-  const handleRunAdHoc = useCallback((nextSql: string) => {
-    setIsRefreshing(true);
-    getVscodeApi()?.postMessage({ type: 'runAdHoc', sql: nextSql });
-  }, []);
+  /**
+   * "Open in Editor" handler — receives whichever SQL the modal is
+   * currently showing.
+   *   - When the user is viewing the source query (`sqlToOpen === sql`),
+   *     post `goToSource`. The host reveals the existing .sql editor tab
+   *     when the panel was opened from a file, or creates a new untitled
+   *     .sql doc otherwise.
+   *   - When the user has the filtered/sorted form displayed, post
+   *     `openAsSql` with that SQL so the host opens an untitled .sql
+   *     doc containing the exact query they're looking at.
+   */
+  const handleOpenInEditor = useCallback((sqlToOpen: string) => {
+    if (sqlToOpen === sql) {
+      getVscodeApi()?.postMessage({ type: 'goToSource' });
+    } else {
+      getVscodeApi()?.postMessage({ type: 'openAsSql', sql: sqlToOpen });
+    }
+  }, [sql]);
 
   // --------------------------------------------------------------------------
   // Selection helpers — operate on absolute row indexes.
@@ -944,20 +1002,10 @@ export function ResultsTable({
       {showSqlModal && (
         <SqlModal
           sql={sql}
+          filteredSql={fullSql !== sql ? fullSql : undefined}
           onClose={() => setShowSqlModal(false)}
           onCopy={(text) => copyToClipboard(text, 'SQL')}
-          onGoToSource={handleGoToSource}
-          onRun={handleRunAdHoc}
-        />
-      )}
-
-      {showFullSqlModal && (
-        <SqlModal
-          sql={fullSql}
-          onClose={() => setShowFullSqlModal(false)}
-          onCopy={(text) => copyToClipboard(text, 'SQL')}
-          onRun={handleRunAdHoc}
-          title="View Query"
+          onOpenInEditor={handleOpenInEditor}
         />
       )}
 
@@ -1023,16 +1071,6 @@ export function ResultsTable({
               <span className="stat-label">selected</span>
               <span className="stat-value">{selectionInfo}</span>
             </div>
-          )}
-          {(sort.column || (filterState.filters.length > 0 && !filterState.isPaused)) && (
-            <button
-              className="stat stat-clickable stat-sql"
-              onClick={() => setShowFullSqlModal(true)}
-              title="View current query with filters and sort"
-            >
-              <Code size={12} />
-              <span className="stat-label">SQL</span>
-            </button>
           )}
         </div>
       )}

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -763,6 +763,15 @@ body {
 .table-wrapper {
   flex: 1;
   overflow: auto;
+  /*
+   * Disable browser scroll anchoring. The virtualized table repositions its
+   * rendered rows on every scroll (the spacer heights track scrollTop in the
+   * compressed, >33M-px regime). With anchoring enabled the browser nudges
+   * scrollTop to "preserve" the shifting content, which feeds back into the
+   * repositioning and causes runaway scrolling ("rows ticking up" that never
+   * reaches the bottom). See issue #10.
+   */
+  overflow-anchor: none;
 }
 
 /* Table */
@@ -1308,6 +1317,18 @@ tr.row-selected td.row-number {
   margin: 0;
 }
 
+/* Toggle bar inside the SQL modal — only rendered when a filtered/sorted
+   form of the query exists, so users can flip between "source" and
+   "as actually executed" views. */
+.sql-modal-toggle-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--space-sm) var(--space-lg);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
 /* Editable cell textarea (cell expansion modal in edit mode) */
 .modal-cell-editor {
   font-family: var(--font-mono);
@@ -1361,29 +1382,6 @@ tr.row-selected td.row-number {
 
 @keyframes cell-modal-spin {
   to { transform: rotate(360deg); }
-}
-
-/* Editable SQL textarea — inherits modal-content sizing */
-.modal-sql-editor {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-base);
-  line-height: 1.6;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: var(--space-md);
-  resize: vertical;
-  width: 100%;
-  outline: none;
-  white-space: pre;
-  overflow: auto;
-  min-height: 120px;
-  tab-size: 2;
-}
-
-.modal-sql-editor:focus {
-  border-color: var(--accent-blue);
 }
 
 /* JSON syntax highlighting in modal */
@@ -1711,22 +1709,6 @@ button.stat-clickable.active {
 button.stat-clickable.active .stat-label,
 button.stat-clickable.active .stat-value {
   color: var(--bg-primary);
-}
-
-/* SQL button in stats bar */
-.stat-sql {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.stat-sql svg {
-  color: var(--text-muted);
-}
-
-.stat-sql:hover svg {
-  color: var(--accent-cyan);
 }
 
 /* ========================================

--- a/src/webview/ui/SqlModal.tsx
+++ b/src/webview/ui/SqlModal.tsx
@@ -1,137 +1,87 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { ExternalLink, Play } from 'lucide-react';
+import React, { useState } from 'react';
+import { ExternalLink } from 'lucide-react';
 import { Modal, ModalAction } from './Modal';
 import { SqlSyntaxHighlight } from './SqlHighlight';
+import { Toggle } from './Toggle';
 
 export interface SqlModalProps {
+  /** The source / un-augmented query as the user authored it. */
   sql: string;
-  onClose: () => void;
-  onCopy: (text: string) => void;
-  /** "Go to Source File" action — navigates to the original .sql file */
-  onGoToSource?: () => void;
-  /** "Open in Editor" action — opens the SQL in a new untitled editor */
-  onOpenInEditor?: (sql?: string) => void;
   /**
-   * "Run" action — when provided, the modal becomes an editor and
-   * the user can modify and re-run the SQL with Ctrl/Cmd+Enter.
+   * Optional "with UI filters + sort" wrapped form of the source query.
+   * When provided and different from `sql`, the modal renders a toggle
+   * that lets the user flip between the two views. Defaults to showing
+   * this form so users see the query as it was actually executed.
    */
-  onRun?: (sql: string) => void;
+  filteredSql?: string;
+  onClose: () => void;
+  /** Receives whichever SQL is currently shown. */
+  onCopy: (text: string) => void;
+  /**
+   * "Open in Editor" — receives whichever SQL is currently shown. The
+   * host decides whether to reveal an existing source-file tab or to
+   * open a new untitled .sql doc.
+   */
+  onOpenInEditor?: (sql: string) => void;
   title?: string;
 }
 
+/**
+ * Read-only SQL preview modal. Editing happens in a real SQL editor —
+ * the modal's `Open in Editor` action hands the user off there. We
+ * intentionally do not embed a textarea editor here: the webview can't
+ * replicate syntax highlighting, completions, or error reporting, so a
+ * "looks editable" textarea quietly invites broken SQL (e.g.
+ * `'col' != 'value'` string-literal comparisons that silently match
+ * every row).
+ */
 export function SqlModal({
   sql,
+  filteredSql,
   onClose,
   onCopy,
-  onGoToSource,
   onOpenInEditor,
-  onRun,
   title = 'SQL',
 }: SqlModalProps) {
-  const editable = !!onRun;
-  const [draft, setDraft] = useState(sql);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const hasFiltered = !!filteredSql && filteredSql !== sql;
+  // Default the toggle ON when a filtered form exists — users opening
+  // the modal mid-investigation usually want to see what's actually
+  // running, not the original literal text.
+  const [showFiltered, setShowFiltered] = useState(hasFiltered);
 
-  // Keep draft in sync if the upstream SQL changes (e.g. filters tweaked)
-  useEffect(() => {
-    setDraft(sql);
-  }, [sql]);
-
-  // Auto-focus the editor when opened so the user can type immediately
-  useEffect(() => {
-    if (editable) {
-      textareaRef.current?.focus();
-      // Place cursor at end
-      const len = textareaRef.current?.value.length ?? 0;
-      textareaRef.current?.setSelectionRange(len, len);
-    }
-  }, [editable]);
-
-  const isDirty = draft !== sql;
-  const trimmed = draft.trim();
-  const canRun = editable && trimmed.length > 0;
-
-  const handleRun = () => {
-    if (!canRun || !onRun) return;
-    onRun(trimmed);
-    onClose();
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Ctrl/Cmd+Enter runs the query
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-      e.preventDefault();
-      handleRun();
-      return;
-    }
-    // Tab inserts spaces inside the textarea
-    if (e.key === 'Tab' && !e.shiftKey) {
-      e.preventDefault();
-      const ta = e.currentTarget;
-      const start = ta.selectionStart;
-      const end = ta.selectionEnd;
-      const next = draft.slice(0, start) + '  ' + draft.slice(end);
-      setDraft(next);
-      // Restore cursor after the inserted spaces
-      requestAnimationFrame(() => {
-        ta.setSelectionRange(start + 2, start + 2);
-      });
-    }
-  };
+  const displayedSql = hasFiltered && showFiltered ? (filteredSql as string) : sql;
 
   const actions: ModalAction[] = [];
-  if (onGoToSource) {
-    actions.push({
-      icon: <ExternalLink size={14} />,
-      label: 'Go to Source File',
-      onClick: onGoToSource,
-    });
-  }
   if (onOpenInEditor) {
     actions.push({
       icon: <ExternalLink size={14} />,
       label: 'Open in Editor',
-      onClick: () => onOpenInEditor(editable ? draft : undefined),
+      onClick: () => onOpenInEditor(displayedSql),
     });
   }
-  if (canRun) {
-    actions.push({
-      icon: <Play size={14} />,
-      label: isDirty ? 'Run edited SQL (⌘↵)' : 'Run SQL (⌘↵)',
-      onClick: handleRun,
-    });
-  }
-
-  const valueForCopy = editable ? draft : sql;
-  const hint = editable
-    ? 'Edit and press ⌘↵ to run · Esc to close'
-    : 'Press Esc to close';
 
   return (
     <Modal
       title={title}
       onClose={onClose}
-      onCopy={() => onCopy(valueForCopy)}
-      size={`${valueForCopy.length.toLocaleString()} chars`}
+      onCopy={() => onCopy(displayedSql)}
+      size={`${displayedSql.length.toLocaleString()} chars`}
       className="sql-modal"
       actions={actions.length > 0 ? actions : undefined}
-      hint={hint}
+      hint="Press Esc to close"
     >
-      {editable ? (
-        <textarea
-          ref={textareaRef}
-          className="modal-content modal-sql-editor"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={handleKeyDown}
-          spellCheck={false}
-          rows={Math.min(24, Math.max(6, draft.split('\n').length + 1))}
-        />
-      ) : (
-        <pre className="modal-content modal-sql">
-          <SqlSyntaxHighlight sql={sql} />
-        </pre>
+      {hasFiltered && (
+        <div className="sql-modal-toggle-bar">
+          <Toggle
+            checked={showFiltered}
+            onChange={setShowFiltered}
+            label="Apply filters & sort"
+          />
+        </div>
       )}
+      <pre className="modal-content modal-sql">
+        <SqlSyntaxHighlight sql={displayedSql} />
+      </pre>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary

Release prep for **v0.0.27**. Bumps the version, updates the changelog, and ships this round of data-viewer fixes and the DuckDB runtime update.

- **SQL preview modals are read-only again; editing happens in a real editor.** The in-panel SQL editor added in 0.0.26 is removed — "View SQL" / "SQL Preview" is a syntax-highlighted, read-only preview. **Open in Editor** / **Go to Source File** hand the query off to a first-class SQL editor (highlighting, completion, error reporting). The separate filtered/sorted "View Query" modal is folded into the single SQL modal behind an **Apply filters & sort** toggle (shown only when a filter or sort is active), and the standalone "SQL" badge in the stats bar is removed.
- **Running a query opened from the data viewer reuses its panel.** "Open in Editor" from a file/table overview, then running the SQL, replaces the originating viewer panel instead of spawning a separate results tab.
- **Bump `@duckdb/node-api` 1.5.2-r.1 → 1.5.3-r.2** (DuckDB engine v1.5.3).

## Fixes

- **Infinite scroll could not reach rows past ~883k** in large results. The virtual scroll surface exceeded the browser's max element height (2^24 px), clamping everything beyond it out of reach. The surface is now capped below that ceiling and scaled, so every row in multi-million-row results is reachable; scroll anchoring is disabled on the viewport to prevent a feedback loop. Below ~420k rows scrolling is unchanged (1:1).

  Closes #10
- **Editing the query inline in the results panel didn't update the view** and reset the horizontal scroll position. Inline query editing is removed in favor of editing in a real SQL editor.

  Closes #12

## Test plan

- [ ] Open a multi-million-row parquet (e.g. 3M rows); scroll to the very bottom and confirm the last row is reachable and the viewport stays put.
- [ ] Confirm results under ~420k rows still scroll 1:1 (no behavior change).
- [ ] "View SQL" modal is read-only; "Open in Editor" opens an editor with the query.
- [ ] With a filter/sort active, the SQL modal shows the "Apply filters & sort" toggle and reflects the augmented query.
- [ ] From a parquet/table overview, "Open in Editor" + run reuses the same viewer panel (no second results tab); closing the viewer falls back to a normal results panel.
- [ ] CI integration tests pass on macOS / Ubuntu / Windows.

Merging to `main` and tagging `v0.0.27` triggers the publish pipeline (VS Code Marketplace + Open VSX).

Made with [Cursor](https://cursor.com)